### PR TITLE
what link through yonder README.md breaks?

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,15 @@ Fae requires Rails >= 4.1.
 
 ## Documentation
 
-### Installation and Usage
+* [Installation and Usage](docs/index.md)
+* [Form and View Helpers](docs/helpers.md)
+* [Upgrading Guide](docs/upgrading.md)
+* [Changelog](CHANGELOG.md)
+* [Contributing and Maintenance](CONTRIBUTING.md)
 
-https://bitbucket.org/wearefine/fae/src/master/docs/index.md
+## License
 
-### Form and View Helpers
-
-https://bitbucket.org/wearefine/fae/src/master/docs/helpers.md
-
-### Upgrading Guide
-
-https://bitbucket.org/wearefine/fae/src/master/docs/upgrading.md
-
-### Changelog
-
-https://bitbucket.org/wearefine/fae/src/master/CHANGELOG.md
-
-### Contibuting and Maintenance
-
-https://bitbucket.org/wearefine/fae/src/master/CONTRIBUTING.md
-
-### License
-
-https://bitbucket.org/wearefine/fae/src/master/LICENSE
+[MIT](LICENSE)
 
 
 


### PR DESCRIPTION
None o' them bitbucket links work unless one has a bitbucket account -- what you think about making them relative? On Github at least a link in the `README.md` like `[contributing](CONTRIBUTING.md)` will work as a link to the `CONTRIBUTING.md` file in the root of the project.