### PR TITLE
refs #54058 - replace accented characters in slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
     + \#48759: Index-page filters collapse beneath each other on overflow
     + Update docs with missing 'not' so it's clear assets aren't cloneable
     + \#54606: Update initial inject_into_file for routes to handle more variations of file's opening line.
+    + \#54058: Replace accented characters with non-accented counterparts in slug generation
+
 ## 1.2.3
 
 - enhancements

--- a/app/assets/javascripts/fae/form/inputs/_text.js
+++ b/app/assets/javascripts/fae/form/inputs/_text.js
@@ -74,16 +74,28 @@ Fae.form.text = {
     });
 
     // Combine all active slug fields for the query
+    slug_text = slug_text.join(' ');
+
+    // Strip accented characters
+    var from = 'àáâãäæåçèéêëęēėìíîïñòóôõöùúûüýÿÀÁÂÃÄÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝ';
+    var to = 'aaaaaaaceeeeeeeiiiinooooouuuuyyAAAAACEEEEIIIINOOOOOUUUUY';
+
+    // Loop through all accented characters and replace with non-accents
+    for (var i = 0; i < from.length; i++) {
+      slug_text = slug_text.replace( new RegExp(from.charAt(i), 'g'), to.charAt(i) );
+    }
+
+    // Remove leading and trailing spaces
     // Make them lowercase
     // Remove slashes, quotes or periods
     // Replace white spaces with a dash
     // Remove leading and trailing dashes
     slug_text = slug_text
-      .join(' ')
+      .trim()
       .toLowerCase()
-      .replace(/(\\)|(\')|(\.)/g, '')
-      .replace(/[^a-zA-Z0-9]+/g, '-')
-      .replace(/(-$)|(^-)/g, '');
+      .replace(/[^-\w\s]/g, '')
+      .replace(/[-\s]+/g, '-')
+      .replace(/(^-)|(-$)/g, '');
 
     return slug_text;
   },

--- a/spec/features/slug_spec.rb
+++ b/spec/features/slug_spec.rb
@@ -54,4 +54,16 @@ feature 'slug' do
     end
   end
 
+
+  context "when the slug has accented characters" do
+    scenario 'should slug the slugger', js: true do
+      admin_login
+      visit new_admin_release_path
+
+      fill_in 'Name', with: "Á förêígn dîÂlëçt ìs gôòd fór thè söül"
+      # Character count limits, sadly
+      expect(find_field('Slug').value).to eq('a-foreign-diale')
+    end
+  end
+
 end


### PR DESCRIPTION
* Replaces accented characters with non-accented ones in slugger
* Improves efficiency of slugger `RegEx` series