### PR TITLE
log a console error when trying to create first user without admin role 

### DIFF
--- a/app/controllers/fae/setup_controller.rb
+++ b/app/controllers/fae/setup_controller.rb
@@ -1,6 +1,7 @@
 module Fae
   class SetupController < ActionController::Base
 
+    before_action :check_roles
     layout 'devise'
 
     def first_user
@@ -15,10 +16,6 @@ module Fae
       super_admin   = Fae::Role.find_by_name('super admin')
       @user.role    = super_admin
       @user.active  = true
-
-      if Fae::Role.all.empty?
-        logger.error("Role 'super admin' does not exist in Fae::Role, run rake fae:seed_db")
-      end
 
       if @user.save
         sign_in(@user)
@@ -39,5 +36,10 @@ module Fae
       params.require(:user).permit(:email, :first_name, :last_name, :password, :password_confirmation)
     end
 
+    def check_roles 
+      if Fae::Role.all.empty?
+        raise "Role 'super admin' does not exist in Fae::Role, run rake fae:seed_db"
+      end
+    end
   end
 end

--- a/app/controllers/fae/setup_controller.rb
+++ b/app/controllers/fae/setup_controller.rb
@@ -16,6 +16,10 @@ module Fae
       @user.role    = super_admin
       @user.active  = true
 
+      if Fae::Role.all.empty?
+        logger.error("Role 'super admin' does not exist in Fae::Role, run rake fae:seed_db")
+      end
+
       if @user.save
         sign_in(@user)
         redirect_to fae.root_path

--- a/spec/features/custom_assets_spec.rb
+++ b/spec/features/custom_assets_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 feature 'Custom assets' do
 
   scenario 'should allow custom JS from main app', js: true do
+    FactoryGirl.create(:fae_role, name: 'super admin')
     visit fae.root_path
     # custom JS adds 'test-class' to '.login-body'
     expect(page).to have_selector('.login-body.test-class')

--- a/spec/requests/fae/setup_spec.rb
+++ b/spec/requests/fae/setup_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'setup#first_user' do
 
   context 'when there are no super admins' do
+    FactoryGirl.create(:fae_role, name: 'super admin')
     it 'should redirect you to setup#first_user' do
       get fae.root_path
 

--- a/spec/requests/fae/setup_spec.rb
+++ b/spec/requests/fae/setup_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe 'setup#first_user' do
 
   context 'when there are no super admins' do
-    FactoryGirl.create(:fae_role, name: 'super admin')
     it 'should redirect you to setup#first_user' do
       get fae.root_path
 

--- a/spec/requests/fae/setup_spec.rb
+++ b/spec/requests/fae/setup_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 describe 'setup#first_user' do
 
   context 'when there are no super admins' do
+    before :each do 
+      FactoryGirl.create(:fae_role, name: 'super admin')
+    end
+    
     it 'should redirect you to setup#first_user' do
       get fae.root_path
 


### PR DESCRIPTION
I ran into this silent fail after dropping my db(post fae install). I couldn't figure out why Fae would not allow the creation of a new first user. After digging into the code, I found that fae fails silently if there isn't a 'super admin' role in the Fae::Role table (originally generated by fae:seed_db).  

Added a simple log message to indicate the error. 