### PR TITLE
add delete_path option to fae_delete_button

### DIFF
--- a/app/assets/stylesheets/fae/modules/tables/_actions.scss
+++ b/app/assets/stylesheets/fae/modules/tables/_actions.scss
@@ -12,23 +12,20 @@ th {
   }
 }
 
-td {
-  &.-action {
-    text-align: center;
+.table-action {
+  text-align: center;
+  color: $c-darker-grey;
+  display: block;
+  padding: 2px;
+  font-size: 16px;
+  text-decoration: none;
 
-    a {
-      color: $c-darker-grey;
-      display: block;
-      padding: 2px;
-      font-size: 16px;
-      text-decoration: none;
-
-      &:hover {
-        color: $c-mid-dark-grey;
-      }
-    }
+  &:hover {
+    color: $c-mid-dark-grey;
   }
+}
 
+td {
   i + a {
     display: inline-block;
     padding-left: 8px;

--- a/app/helpers/fae/view_helper.rb
+++ b/app/helpers/fae/view_helper.rb
@@ -44,15 +44,15 @@ module Fae
 
     def fae_clone_button(item)
       return if item.blank?
-      link_to "#{@index_path}?from_existing=#{item.id}", method: :post, title: 'Clone', class: 'js-tooltip', data: { confirm: t('fae.clone_confirmation') } do
+      link_to "#{@index_path}?from_existing=#{item.id}", method: :post, title: 'Clone', class: 'js-tooltip table-action', data: { confirm: t('fae.clone_confirmation') } do
         concat content_tag :i, nil, class: 'icon-copy'
       end
     end
 
-    def fae_delete_button(item)
+    def fae_delete_button(item, delete_path = nil)
       return if item.blank?
-      delete_path = polymorphic_path([main_app, fae_scope, item.try(:fae_parent), item])
-      link_to delete_path, method: :delete, title: 'Delete', class: 'js-tooltip', data: { confirm: t('fae.delete_confirmation') } do
+      delete_path ||= polymorphic_path([main_app, fae_scope, item.try(:fae_parent), item])
+      link_to delete_path, method: :delete, title: 'Delete', class: 'js-tooltip table-action', data: { confirm: t('fae.delete_confirmation') } do
         concat content_tag :i, nil, class: 'icon-trash'
       end
     end

--- a/app/views/fae/shared/_shared_nested_table.html.slim
+++ b/app/views/fae/shared/_shared_nested_table.html.slim
@@ -32,11 +32,11 @@ table class=table_class
             - options_for_td[:item] = item
             = td_columns(options_for_td)
           - if edit_column
-            td.-action
+            td
               a.js-edit-link href=self.send(edit_path, item)
                 i.icon-edit
-          td.-action
-            = link_to '', "/#{fae_path}/#{assoc_name}/#{item.id.to_s}", method: :delete, defaults: { confirm: t('fae.delete_confirmation') }, class: 'js-delete-link icon-trash', remote: true
+          td
+            = link_to '', "/#{fae_path}/#{assoc_name}/#{item.id.to_s}", method: :delete, defaults: { confirm: t('fae.delete_confirmation') }, class: 'js-delete-link icon-trash table-action', remote: true
     - else
       tr
         - if index

--- a/app/views/fae/users/index.html.slim
+++ b/app/views/fae/users/index.html.slim
@@ -20,7 +20,4 @@ main.content
           td = user.role.name
           td = fae_date_format user.last_sign_in_at if user.last_sign_in_at.present?
           td = attr_toggle user, :active unless current_user == user
-          td.-action
-            - unless current_user == user
-              = link_to user, method: :delete, data: { confirm: t('fae.delete_confirmation') }
-                i.icon-trash
+          td = fae_delete_button user, user unless current_user == user

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -405,6 +405,11 @@ fae_clone_button item
 
 You can use `fae_delete_button` in your list view tables to provide easy access to delete an item.
 
+| option | type | description |
+|---|---|---|
+| item | ActiveRecord object | item to be deleted |
+| delete_path (optional) | String|Route helper | delete endpoint |
+
 ```ruby
 fae_delete_button item
 ```

--- a/lib/generators/fae/templates/views/index.html.slim
+++ b/lib/generators/fae/templates/views/index.html.slim
@@ -32,6 +32,6 @@ main.content
 <% @toggle_attrs.each do |attr| -%>
             td = fae_toggle item, :<%= attr %>
 <% end -%>
-            td.-action = fae_delete_button item
+            td = fae_delete_button item
       - else
         tr: td colspan="<%= num_columns %>" No items found

--- a/spec/dummy/app/views/admin/acclaims/index.html.erb
+++ b/spec/dummy/app/views/admin/acclaims/index.html.erb
@@ -25,7 +25,7 @@
               <td><%= fae_date_format item.updated_at %></td>
               <td><%= fae_toggle item, :on_stage %></td>
               <td><%= fae_toggle item, :on_prod %></td>
-              <td class="-action"><%= fae_delete_button item %></td>
+              <td><%= fae_delete_button item %></td>
             </tr>
           <% end %>
         </tbody>

--- a/spec/dummy/app/views/admin/coaches/index.html.slim
+++ b/spec/dummy/app/views/admin/coaches/index.html.slim
@@ -14,7 +14,7 @@ main.content
           tr id="#{@klass_singular}_#{item.id}"
             td = link_to item.fae_display_field, edit_admin_team_coach_path(@parent_item, item)
             td = fae_date_format item.updated_at
-            td.-action = fae_delete_button item
+            td = fae_delete_button item
       - else
         tr
           td colspan="3" No items found

--- a/spec/dummy/app/views/admin/events/index.html.erb
+++ b/spec/dummy/app/views/admin/events/index.html.erb
@@ -32,7 +32,7 @@
                 <td>Extra cell</td>
                 <td>Fourth cell</td>
                 <td>###</td>
-                <td class="-action"><%= fae_delete_button item %></td>
+                <td><%= fae_delete_button item %></td>
               </tr>
             <% end %>
           </tbody>
@@ -65,7 +65,7 @@
                 <td>Extra cell</td>
                 <td>Fourth cell</td>
                 <td>###</td>
-                <td class="-action"><%= fae_delete_button item %></td>
+                <td><%= fae_delete_button item %></td>
               </tr>
             <% end %>
           </tbody>
@@ -98,7 +98,7 @@
                 <td>Extra cell</td>
                 <td>Fourth cell</td>
                 <td>###</td>
-                <td class="-action"><%= fae_delete_button item %></td>
+                <td><%= fae_delete_button item %></td>
               </tr>
             <% end %>
           </tbody>
@@ -131,7 +131,7 @@
                 <td>Extra cell</td>
                 <td>Fourth cell</td>
                 <td>###</td>
-                <td class="-action"><%= fae_delete_button item %></td>
+                <td><%= fae_delete_button item %></td>
               </tr>
             <% end %>
           </tbody>

--- a/spec/dummy/app/views/admin/locations/index.html.slim
+++ b/spec/dummy/app/views/admin/locations/index.html.slim
@@ -17,7 +17,7 @@ main.content
           tr id="#{@klass_singular}_#{item.id}"
             td = link_to item.fae_display_field, edit_admin_location_path(item)
             td = fae_date_format item.updated_at
-            td.-action = fae_delete_button item
+            td = fae_delete_button item
       - else
         tr
           td colspan="3" No items found

--- a/spec/dummy/app/views/admin/people/index.html.erb
+++ b/spec/dummy/app/views/admin/people/index.html.erb
@@ -27,7 +27,7 @@
               <td><%= fae_date_format item.updated_at %></td>
               <td><%= fae_toggle item, :on_stage %></td>
               <td><%= fae_toggle item, :on_prod %></td>
-              <td class="-action"><%= fae_delete_button item %></td>
+              <td><%= fae_delete_button item %></td>
             </tr>
           <% end %>
         </tbody>

--- a/spec/dummy/app/views/admin/players/index.html.slim
+++ b/spec/dummy/app/views/admin/players/index.html.slim
@@ -14,7 +14,7 @@ main.content
           tr id="#{@klass_singular}_#{item.id}"
             td = link_to item.fae_display_field, edit_admin_team_player_path(@parent_item, item)
             td = fae_date_format item.updated_at
-            td.-action = fae_delete_button item
+            td = fae_delete_button item
       - else
         tr
           td colspan="3" No items found

--- a/spec/dummy/app/views/admin/releases/index.html.slim
+++ b/spec/dummy/app/views/admin/releases/index.html.slim
@@ -36,7 +36,7 @@ main.content
             td = fae_date_format item.updated_at
             td = fae_toggle item, :on_stage
             td = fae_toggle item, :on_prod
-            td.-action = fae_clone_button item
-            td.-action = fae_delete_button item
+            td = fae_clone_button item
+            td = fae_delete_button item
       - else
         tr: td colspan="9" No items found

--- a/spec/dummy/app/views/admin/selling_points/index.html.erb
+++ b/spec/dummy/app/views/admin/selling_points/index.html.erb
@@ -29,7 +29,7 @@
                 <td><%= fae_date_format item.updated_at %></td>
                 <td><%= fae_toggle item, :on_stage %></td>
                 <td><%= fae_toggle item, :on_prod %></td>
-                <td class="-action"><%= fae_delete_button item %></td>
+                <td><%= fae_delete_button item %></td>
               </tr>
             <% end %>
           </tbody>

--- a/spec/dummy/app/views/admin/teams/index.html.slim
+++ b/spec/dummy/app/views/admin/teams/index.html.slim
@@ -14,7 +14,7 @@ main.content
           tr id="#{@klass_singular}_#{item.id}"
             td = link_to item.fae_display_field, edit_admin_team_path(item)
             td = fae_date_format item.updated_at
-            td.-action = fae_delete_button item
+            td = fae_delete_button item
       - else
         tr
           td colspan="3" No items found

--- a/spec/dummy/app/views/admin/validation_testers/index.html.slim
+++ b/spec/dummy/app/views/admin/validation_testers/index.html.slim
@@ -14,7 +14,7 @@ main.content
           tr id="#{@klass_singular}_#{item.id}"
             td = link_to item.fae_display_field, edit_admin_validation_tester_path(item)
             td = fae_date_format item.updated_at
-            td.-action = fae_delete_button item
+            td = fae_delete_button item
       - else
         tr
           td colspan="3" No items found

--- a/spec/dummy/app/views/admin/varietals/index.html.erb
+++ b/spec/dummy/app/views/admin/varietals/index.html.erb
@@ -25,7 +25,7 @@
               <td><%= fae_date_format item.updated_at %></td>
               <td><%= fae_toggle item, :on_stage %></td>
               <td><%= fae_toggle item, :on_prod %></td>
-              <td class="-action"><%= fae_delete_button item %></td>
+              <td><%= fae_delete_button item %></td>
             </tr>
           <% end %>
         </tbody>

--- a/spec/dummy/app/views/admin/wines/index.html.slim
+++ b/spec/dummy/app/views/admin/wines/index.html.slim
@@ -20,4 +20,4 @@ main.content
           td = fae_date_format item.updated_at
           td = fae_toggle item, :on_stage
           td = fae_toggle item, :on_prod
-          td.-action = fae_delete_button item
+          td = fae_delete_button item

--- a/spec/features/clone_spec.rb
+++ b/spec/features/clone_spec.rb
@@ -70,7 +70,7 @@ feature 'Clone record' do
       release = FactoryGirl.create(:release, name: 'Ima Release', vintage: '2012', price: 13, varietal_id: 2, show: Date.today)
       admin_login
       visit admin_releases_path
-      page.find('td.-action a[title="Clone"]').click
+      page.find('a.table-action[title="Clone"]').click
 
       # support/async_helper.rb
       eventually {
@@ -85,7 +85,7 @@ feature 'Clone record' do
       release = FactoryGirl.create(:release, name: 'Ima Release', vintage: '2012', on_prod: true, price: 13, varietal_id: 2, show: Date.today)
       admin_login
       visit admin_releases_path
-      page.find('td.-action a[title="Clone"]').click
+      page.find('a.table-action[title="Clone"]').click
 
       eventually {
         expect(find_field('release_on_prod_false').value).to eq('false')

--- a/spec/helpers/fae_view_helper_spec.rb
+++ b/spec/helpers/fae_view_helper_spec.rb
@@ -78,4 +78,29 @@ describe Fae::ViewHelper do
     end
   end
 
+  describe '#fae_delete_button' do
+    # Necessary for fae_scope in the fae_delete_button method
+    include Fae::ApplicationHelper
+
+    it 'should include a polymorphic path when fae_parent is present' do
+      item = FactoryGirl.create(:coach)
+      expect( fae_delete_button(item) ).to match /\/admin\/teams\/\d+\/coaches\/\d+/
+    end
+
+    it 'should include a regular path when fae_parent is not present' do
+      item = FactoryGirl.create(:release)
+      expect( fae_delete_button(item) ).to match /\/admin\/releases\/\d+/
+    end
+
+    it 'should include a custom path when a second argument is supplied' do
+      item = FactoryGirl.create(:coach)
+
+      # as a Rails path helper
+      expect( fae_delete_button(item, ['admin', item.team, item]) ).to match /\/admin\/teams\/\d+\/coaches\/\d+/
+
+      # as a string
+      expect( fae_delete_button(item, '/admin/custom/route') ).to match /\/admin\/custom\/route/
+    end
+  end
+
 end


### PR DESCRIPTION
some edge cases for the fae_delete_button have @parent defined in the controller and not as fae_parent on the model. This allows a custom delete_path to be passed.

Also, I removed some extra markup to make it more future-update-proof.