### PR TITLE
57158 - Fae::Navigation#current_section no longer removes '/new' from…

### DIFF
--- a/app/models/fae/navigation.rb
+++ b/app/models/fae/navigation.rb
@@ -20,6 +20,10 @@ module Fae
       find_items_by_text(structure, query, [])
     end
 
+    def current_section
+      @current_path.gsub(/\/new$|\/\d+\/edit/, '')
+    end
+
     private
 
     def find_current_hash(array_of_items)
@@ -55,10 +59,6 @@ module Fae
     def increment_coordinates
       last_item = @coordinates.pop
       @coordinates.push(last_item + 1)
-    end
-
-    def current_section
-      @current_path.gsub(/\/new|\/\d+\/edit/, '')
     end
 
     def item(text, options={})

--- a/spec/models/fae/navigation_spec.rb
+++ b/spec/models/fae/navigation_spec.rb
@@ -39,4 +39,31 @@ describe Fae::Navigation do
 
     end
   end
+
+  describe '.current_section' do
+    it "should remove '/new' at the end of a URL" do
+      nav = Fae::Navigation.new('/admin/cat_busses/new')
+      expect(nav.current_section).to eq('/admin/cat_busses')
+    end
+
+    it "should leave '/new' in the middle of a URL" do
+      nav = Fae::Navigation.new('/admin/news_items/new')
+      expect(nav.current_section).to eq('/admin/news_items')
+    end
+
+    it "should remove '/#/edit' at the end of a URL" do
+      nav = Fae::Navigation.new('/admin/totoros/2/edit')
+      expect(nav.current_section).to eq('/admin/totoros')
+    end
+
+    it "should leave '/edit' in the middle of a URL" do
+      nav = Fae::Navigation.new('/admin/editors/new')
+      expect(nav.current_section).to eq('/admin/editors')
+    end
+
+    it 'should leave index URLs the same' do
+      nav = Fae::Navigation.new('/admin/news_items')
+      expect(nav.current_section).to eq('/admin/news_items')
+    end
+  end
 end


### PR DESCRIPTION
… the middle of the URL string