### PR TITLE
57075 - add a --fine flag to the install generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - enhancements
     + Generated nested table controllers are now empty and inherit from `Fae::NestedBaseController`
+    + \#57075: Add a flag to the install generator for internal usage
 - bugs
     + Disabled checkboxes are now untouchable
     + Multiselect headers update available/added items accurately

--- a/lib/generators/fae/install_generator.rb
+++ b/lib/generators/fae/install_generator.rb
@@ -2,6 +2,7 @@ module Fae
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
     class_option :namespace, type: :string, default: 'admin', desc: 'Sets the namespace of the generator'
+    class_option :fine, type: :boolean, default: false, desc: 'Sets FINE\'s defaults'
 
     def install
       run 'bundle install'
@@ -39,7 +40,8 @@ RUBY
     end
 
     def build_initializer
-      copy_file File.expand_path(File.join(__FILE__, "../templates/initializers/fae.rb")), "config/initializers/fae.rb"
+      init_source = options.fine ? "../templates/initializers/fae_fine.rb" : "../templates/initializers/fae.rb"
+      copy_file File.expand_path(File.join(__FILE__, init_source)), "config/initializers/fae.rb"
       inject_into_file "config/initializers/fae.rb", after: "Fae.setup do |config|\n" do <<-RUBY
 \n  config.devise_secret_key = '#{SecureRandom.hex(64)}'\n
 RUBY

--- a/lib/generators/fae/templates/initializers/fae_fine.rb
+++ b/lib/generators/fae/templates/initializers/fae_fine.rb
@@ -52,5 +52,5 @@ Fae.setup do |config|
   ## disabled_environments
   # This option will disable Fae complete when the app is running
   # on one of the defined environments
-  # config.disabled_environments = [ :preview, :staging ]
+  config.disabled_environments = [ :stage ]
 end


### PR DESCRIPTION
Adds a FINE flage for internal usage. That way we can have a set of internal standards without making them global.

```
rails g fae:install --fine
```