### PR TITLE
Page with lang fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     + \#59473: Reinitialize form elements on redrawing of nested forms
     + \#59386: Show sub page indicator as "open" when landing on an active view
     + \#58752: Languages should load from previously selected preference
+    + Default language on static pages should be the first defined
 
 ## 1.3.1
 

--- a/app/models/fae/static_page.rb
+++ b/app/models/fae/static_page.rb
@@ -39,7 +39,7 @@ module Fae
             define_validations("#{name}_#{lang}", type, value[:validates]) if value.try(:[], :validates).present?
           end
           # Save with lookup to have default language return in front-end use (don't need to worry about validations here)
-          define_association(name, type, "#{name}_#{I18n.locale}")
+          define_association(name, type, "#{name}_#{languages.first}")
         else
           # Normal content_blocks
           define_association(name, type)

--- a/app/models/fae/static_page.rb
+++ b/app/models/fae/static_page.rb
@@ -39,7 +39,8 @@ module Fae
             define_validations("#{name}_#{lang}", type, value[:validates]) if value.try(:[], :validates).present?
           end
           # Save with lookup to have default language return in front-end use (don't need to worry about validations here)
-          define_association(name, type, "#{name}_#{languages.first}")
+          default_language = Rails.application.config.i18n.default_locale || languages.first
+          define_association(name, type, "#{name}_#{default_language}")
         else
           # Normal content_blocks
           define_association(name, type)


### PR DESCRIPTION
Since the pages associated are only defined the first time they are called, the default association on static page attributes should default to something more predictable.

Currently the default association is set to whatever the locale of the person to call it has set and will stay that way until restart.

cc @tshedor 