### PR TITLE
removes old vendor directory

### DIFF
--- a/fae.gemspec
+++ b/fae.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "A flexible CMS for Rails"
   s.license     = "MIT"
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
   # Rails dependencies


### PR DESCRIPTION
@LeChin Looks like the vendor directory wasn't being tracked to begin with, so I just needed to remove the reference from the gemspec.