### PR TITLE
Activity log pagination rendering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - enhancements
 - bugs
+    + Fix bug in activity log paging where certain cases or Kaminari's page object won't convert to a page number
 
 ## 1.4
 

--- a/app/views/kaminari/fae/_page.html.slim
+++ b/app/views/kaminari/fae/_page.html.slim
@@ -8,8 +8,8 @@
 /   remote:        data-remote
 - if page.current?
   span.page.current
-    == page
+    == page.number
 - else
   - rel = page.next? ? 'next' : page.prev? ? 'prev' : nil
   span.page
-    a href=url rel=rel remote=remote data-page=page = page
+    a href=url rel=rel remote=remote data-page=page.number = page.number


### PR DESCRIPTION
Fix bug in activity log paging where certain cases or Kaminari's page object won't convert to a page number.

Kaminari's `page` view helper was triggering `NoMethodError: undefined method `to_i' for true:TrueClass`. My fix is to specifically call the `number` method on the object.