### PR TITLE
Refs #61045 - Adds a max-height constraint to .asset-actions image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - enhancements
 - bugs
+    + Ensure max-height of asset preview within image uploader
     + Fix bug in activity log paging where certain cases or Kaminari's page object won't convert to a page number
 
 ## 1.4

--- a/app/assets/stylesheets/fae/modules/forms/_asset-actions.scss
+++ b/app/assets/stylesheets/fae/modules/forms/_asset-actions.scss
@@ -22,7 +22,8 @@
   }
 
   > img {
-    width: 20%;
+    max-width: 20%;
+    max-height: 150px;
     margin-right: 20px;
     cursor: pointer;
     float: left;


### PR DESCRIPTION
Ensure that asset preview within image uploader doesn't take up more than 150px of vertical space