### PR TITLE
Refs #61164 - Colorize form section headings per $c-custom-highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - enhancements
 - bugs
+    + \#61164: Colorize form section headings per $c-custom-highlight
     + \#60547: Tighten vertical padding of list view rows
     + \#59915: Tighten default column widths on list views
     + \#59343: Add drop-up support for select boxes at bottom of viewport. Increase default height of drop menus

--- a/app/assets/stylesheets/fae/globals/imports/_variables.scss
+++ b/app/assets/stylesheets/fae/globals/imports/_variables.scss
@@ -71,7 +71,6 @@ $c-header-bg: $c-darkest-grey !default;
 
 // Content Headers
 $c-content-header-bg: $c-white !default;
-$c-content-section-title: $c-lightest-grey !default;
 
 // Tables
 $c-table-th: $c-grey !default;

--- a/app/assets/stylesheets/fae/globals/imports/finescss/_fine_functions.scss
+++ b/app/assets/stylesheets/fae/globals/imports/finescss/_fine_functions.scss
@@ -57,3 +57,19 @@
     @return #00f;
   }
 }
+
+/// Choose from a light or dark contrasting foreground color given a background
+@function pickForegroundColor($background, $c-light, $c-dark) {
+  $r: red($background);
+  $g: green($background);
+  $b: blue($background);
+
+  $yiq: (($r*299)+($g*587)+($b*114))/1000;
+
+  @if ($yiq >= 170) {
+    @return $c-dark; // Dark foreground
+  }
+  @else {
+    @return $c-light; // Light foreground
+  }
+}

--- a/app/assets/stylesheets/fae/globals/imports/finescss/_fine_functions.scss
+++ b/app/assets/stylesheets/fae/globals/imports/finescss/_fine_functions.scss
@@ -46,9 +46,9 @@
   @return false;
 }
 
-/// Grabs a color from $grays map
-/// @param {key} $key - Key to get value from $grays map
-/// @return - Color value
+// Grabs a color from $grays map
+// @param {key} $key - Key to get value from $grays map
+// @return - Color value
 @function gray($key: 30) {
   @if map-has-key($grays, $key) {
     @return map-get($grays, $key);
@@ -58,7 +58,8 @@
   }
 }
 
-/// Choose from a light or dark contrasting foreground color given a background
+// Choose from a light or dark contrasting foreground color given a background
+// Original function: https://medium.com/@mkel23/calculating-color-contrast-with-sass-eff39ef23f96
 @function pickForegroundColor($background, $c-light, $c-dark) {
   $r: red($background);
   $g: green($background);

--- a/app/assets/stylesheets/fae/globals/layout/_base.scss
+++ b/app/assets/stylesheets/fae/globals/layout/_base.scss
@@ -27,8 +27,8 @@
 
   h2 {
     padding: 17px $content-buffer;
-    color: $c-text-heavy;
-    background: $c-content-section-title;
+    color: pickForegroundColor($c-custom-highlight, $c-white, $c-black);
+    background: $c-custom-highlight;
     border-top: 1px solid $c-border;
     text-transform: uppercase;
     font-size: 14px;

--- a/app/assets/stylesheets/fae/globals/legacy/_pre-1.3.scss
+++ b/app/assets/stylesheets/fae/globals/legacy/_pre-1.3.scss
@@ -65,8 +65,8 @@
 
 .main_content-section-title {
   padding: 17px 40px;
-  color: $c-text-heavy;
-  background: $c-content-section-title;
+  color: pickForegroundColor($c-custom-highlight, $c-white, $c-black);
+  background: $c-custom-highlight;;
   border-top: 1px solid $c-border;
   text-transform: uppercase;
   font-size: 14px;


### PR DESCRIPTION
* Background & foreground of form section headings based on value of `$c-custom-highlight`
* Can be verified on [Fae staging](http://stage.fae.afinedevelopment.com/admin/releases/3/edit)

Issue: https://issues.afinedevelopment.com/issues/61164