### PR TITLE
138 - sets StaticPage association to not be readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
     + Fixes filter form variable
     + Add .js-results-table class back so activity log page's table can be properly targeted
     + Bump acts_as_list to ~> 0.9.0 to avoid rails 5 deprecation errors
-    + #184: Kaminari/Rails 5 compatibility
+    + Kaminari/Rails 5 compatibility [#184](https://github.com/wearefine/fae/issues/184)
+    + Sets StaticPage associations to not be readonly [#138](https://github.com/wearefine/fae/issues/138)
 
 ## 1.4.1
 

--- a/app/models/fae/static_page.rb
+++ b/app/models/fae/static_page.rb
@@ -10,7 +10,7 @@ module Fae
 
     def self.instance
       setup_dynamic_singleton
-      row = includes(fae_fields.keys).references(fae_fields.keys).find_by_slug(@slug)
+      row = left_joins(fae_fields.keys).readonly(false).references(fae_fields.keys).find_by_slug(@slug)
       row = create(title: @slug.titleize, slug: @slug) if row.blank?
       row
     end


### PR DESCRIPTION
fixes #138 

Sets `readonly` to `false` when a `StaticPage#instance` is called. I was on the fence about changing this call as it will no longer include all associated attributes in one SQL call. After some benchmarking I determined the hit is pretty insignificant, with averages the same on form loads and large page integrations variance <10ms.