### PR TITLE
should not singularize page class name

### DIFF
--- a/lib/generators/fae/templates/controllers/static_pages_controller.rb
+++ b/lib/generators/fae/templates/controllers/static_pages_controller.rb
@@ -4,7 +4,7 @@ module <%= options.namespace.capitalize %>
     private
 
     def fae_pages
-      [<%= "#{class_name.singularize}Page" %>]
+      [<%= "#{class_name}Page" %>]
     end
   end
 end


### PR DESCRIPTION
if you run a page generation at the first time, for example, as in the document

```
rails g fae:page AboutUs hero_image:image headline:string body:text
```

you will get `AboutU` added to the ContentBlocksController instead of `AboutUs`