### PR TITLE
Fix depreciation warning from parametrize method

### DIFF
--- a/app/views/fae/shared/_form_header.html.slim
+++ b/app/views/fae/shared/_form_header.html.slim
@@ -32,5 +32,5 @@ ruby:
 - if subnav.present?
   ul.content-header-subnav#js-content-header-subnav
     - subnav.each do |link, id_selector|
-      - subnav_item = link.is_a?(Array) ? link : [link, link.parameterize('_')]
+      - subnav_item = link.is_a?(Array) ? link : [link, link.parameterize(separator: '_')]
       li: a href="##{subnav_item[1]}" = subnav_item[0]


### PR DESCRIPTION
Note that this warning has been removed in Rails 5.1 but anyway we
better use keyword argument

See : https://github.com/rails/rails/commit/0189f4db6fe518de8909b66b7f30046bac52dedc