### PR TITLE
Use mini_magick instead of rmagick adapter for image processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails', '~> 4.2.1'
 gem 'sass', require: 'sass'
 gem 'carrierwave', '~> 0.10.0'
-gem 'rmagick', '~> 2.13.3', require: false
 
 group :test, :development do
   gem 'rspec-rails', '~> 3.5', '>= 3.5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,9 +19,9 @@ PATH
       judge (~> 2.1.1)
       judge-simple_form (~> 1.0.0)
       kaminari (~> 0.17.0)
+      mini_magick
       rails (>= 4.1)
       remotipart (~> 1.3.1)
-      rmagick (~> 2.13.3)
       sass (>= 3.4.0)
       sass-rails (>= 5.0.3)
       simple_form (>= 3.1.0)
@@ -188,6 +188,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_magick (4.7.0)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -242,7 +243,6 @@ GEM
     remotipart (1.3.1)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
-    rmagick (2.13.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -345,7 +345,6 @@ DEPENDENCIES
   mysql2
   pry
   rails-perftest
-  rmagick (~> 2.13.3)
   rspec-rails (~> 3.5, >= 3.5.2)
   ruby-prof
   sass

--- a/app/uploaders/fae/file_uploader.rb
+++ b/app/uploaders/fae/file_uploader.rb
@@ -2,8 +2,7 @@
 module Fae
   class FileUploader < CarrierWave::Uploader::Base
 
-    # Include RMagick support:
-    # include CarrierWave::RMagick
+    include CarrierWave::MiniMagick
     include CarrierWave::MimeTypes
 
     process :set_content_type

--- a/app/uploaders/fae/image_uploader.rb
+++ b/app/uploaders/fae/image_uploader.rb
@@ -1,8 +1,9 @@
 # encoding: utf-8
 module Fae
   class ImageUploader < CarrierWave::Uploader::Base
+
+    include CarrierWave::MiniMagick
     include CarrierWave::MimeTypes
-    include CarrierWave::RMagick
 
     # saves file size to DB
     process :save_file_size_in_model

--- a/fae.gemspec
+++ b/fae.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-ui-rails', '~> 4.2.1'
   s.add_dependency 'remotipart', '~> 1.3.1'
   s.add_dependency 'carrierwave', '~> 0.10.0'
-  s.add_dependency 'rmagick', '~> 2.13.3'
+  s.add_dependency 'mini_magick'
   s.add_dependency 'judge', '~> 2.1.1'
   s.add_dependency 'judge-simple_form', '~> 1.0.0'
   s.add_dependency 'acts_as_list', '~> 0.9.0'

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -6,7 +6,6 @@ gem "jquery-rails"
 gem "jquery-ui-rails", "~> 4.2.1"
 gem "sass", :require => "sass"
 gem "carrierwave", "~> 0.10.0"
-gem "rmagick", "~> 2.13.3", :require => false
 gem "capistrano", "~> 3.1"
 gem "capistrano-rails", :git => "https://github.com/wearefine/rails"
 gem "capistrano-rvm"

--- a/gemfiles/rails_4_1.gemfile.lock
+++ b/gemfiles/rails_4_1.gemfile.lock
@@ -19,9 +19,9 @@ PATH
       judge (~> 2.1.1)
       judge-simple_form (~> 1.0.0)
       kaminari (~> 0.17.0)
+      mini_magick
       rails (>= 4.1)
       remotipart (~> 1.3.1)
-      rmagick (~> 2.13.3)
       sass (>= 3.4.0)
       sass-rails (>= 5.0.3)
       simple_form (>= 3.1.0)
@@ -172,6 +172,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_magick (4.7.0)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -217,7 +218,6 @@ GEM
     remotipart (1.3.1)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
-    rmagick (2.13.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -318,7 +318,6 @@ DEPENDENCIES
   pry
   rails (~> 4.1.0)
   rails-perftest
-  rmagick (~> 2.13.3)
   rspec-rails (~> 3.5, >= 3.5.2)
   ruby-prof
   sass

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -6,7 +6,6 @@ gem "jquery-rails"
 gem "jquery-ui-rails", "~> 4.2.1"
 gem "sass", :require => "sass"
 gem "carrierwave", "~> 0.10.0"
-gem "rmagick", "~> 2.13.3", :require => false
 gem "capistrano", "~> 3.1"
 gem "capistrano-rails", :git => "https://github.com/wearefine/rails"
 gem "capistrano-rvm"

--- a/gemfiles/rails_4_2.gemfile.lock
+++ b/gemfiles/rails_4_2.gemfile.lock
@@ -19,9 +19,9 @@ PATH
       judge (~> 2.1.1)
       judge-simple_form (~> 1.0.0)
       kaminari (~> 0.17.0)
+      mini_magick
       rails (>= 4.1)
       remotipart (~> 1.3.1)
-      rmagick (~> 2.13.3)
       sass (>= 3.4.0)
       sass-rails (>= 5.0.3)
       simple_form (>= 3.1.0)
@@ -185,6 +185,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_magick (4.7.0)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -241,7 +242,6 @@ GEM
     remotipart (1.3.1)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
-    rmagick (2.13.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -343,7 +343,6 @@ DEPENDENCIES
   rails (~> 4.2.0)
   rails-controller-testing
   rails-perftest
-  rmagick (~> 2.13.3)
   rspec-rails (~> 3.5, >= 3.5.2)
   ruby-prof
   sass

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -6,7 +6,6 @@ gem "jquery-rails"
 gem "jquery-ui-rails", "~> 4.2.1"
 gem "sass", :require => "sass"
 gem "carrierwave", "~> 0.10.0"
-gem "rmagick", "~> 2.13.3", :require => false
 gem "capistrano", "~> 3.1"
 gem "capistrano-rails", :git => "https://github.com/wearefine/rails"
 gem "capistrano-rvm"

--- a/gemfiles/rails_5_0.gemfile.lock
+++ b/gemfiles/rails_5_0.gemfile.lock
@@ -19,9 +19,9 @@ PATH
       judge (~> 2.1.1)
       judge-simple_form (~> 1.0.0)
       kaminari (~> 0.17.0)
+      mini_magick
       rails (>= 4.1)
       remotipart (~> 1.3.1)
-      rmagick (~> 2.13.3)
       sass (>= 3.4.0)
       sass-rails (>= 5.0.3)
       simple_form (>= 3.1.0)
@@ -188,6 +188,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_magick (4.7.0)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -246,7 +247,6 @@ GEM
     remotipart (1.3.1)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
-    rmagick (2.13.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -351,7 +351,6 @@ DEPENDENCIES
   rails (~> 5.0)
   rails-controller-testing
   rails-perftest
-  rmagick (~> 2.13.3)
   rspec-rails (~> 3.5, >= 3.5.2)
   ruby-prof
   sass


### PR DESCRIPTION
RMagick is such a pain to intall because of native extensions failing to
compile with imagemagick v7.x installed.

MiniMagick is much better alternative, ligther dependency and far
sufficient for fae requirements.

You have such a great doc ! This project deserves an easy setup 😉 