### PR TITLE
Fix typos in documentation and test

### DIFF
--- a/docs/topics/models.md
+++ b/docs/topics/models.md
@@ -178,7 +178,7 @@ Here's the breakdown:
 
 ### Other Examples
 
-An onject with many gallery images:
+An object with many gallery images:
 
 ```ruby
 has_many :gallery_images, -> { where(attached_as: 'gallery_images') },
@@ -204,4 +204,3 @@ If the object only has one image association, you can get away with omitting the
 has_one :image, as: :imageable, class_name: '::Fae::Image', dependent: :destroy
 accepts_nested_attributes_for :image, allow_destroy: true
 ```
-

--- a/docs/tutorials/image_and_files.md
+++ b/docs/tutorials/image_and_files.md
@@ -43,7 +43,7 @@ Here's the breakdown:
 
 ### Other Examples
 
-An onject with many gallery images:
+An object with many gallery images:
 
 ```ruby
 has_many :gallery_images, -> { where(attached_as: 'gallery_images') },

--- a/spec/models/fae/sortable_spec.rb
+++ b/spec/models/fae/sortable_spec.rb
@@ -37,7 +37,7 @@ describe Fae::Sortable do
         expect(Cat.fae_sort({ sort_by: 'aroma.pasta' })).to eq(@default_order)
       end
 
-      it "should ignore onjects that aren't present" do
+      it "should ignore objects that aren't present" do
         expect(Cat.fae_sort({ sort_by: 'pasta.name' })).to eq(@default_order)
       end
     end


### PR DESCRIPTION
Just a small typo.

`onject -> object`