### PR TITLE
Small style updates

### DIFF
--- a/app/assets/stylesheets/fae/globals/_tags.scss
+++ b/app/assets/stylesheets/fae/globals/_tags.scss
@@ -62,3 +62,7 @@ img {
 strong {
   font-weight: bold;
 }
+
+abbr {
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/fae/pages/_login.scss
+++ b/app/assets/stylesheets/fae/pages/_login.scss
@@ -39,7 +39,6 @@
     width: 50%;
     padding: 35px 23px;
     border-left: 1px solid $c-border;
-    margin-left: -6px;
   }
 
   input[type=text],
@@ -62,7 +61,8 @@
 .login-logo {
   @include bp(login_container) {
     display: inline-block;
-    vertical-align: center;
+    vertical-align: middle;
+    padding: 0 25px;
     width: 50%;
   }
 }


### PR DESCRIPTION
1. Update `/admin/login` form styling to play well with oversized logos
2. Update `abbr` tag styling to remove default text-decoration (Redmine issue no. 67527)