### PR TITLE
Fix directly inheriting from ActiveRecord::Migration

### DIFF
--- a/db/migrate/20140809222030_add_user_table.rb
+++ b/db/migrate/20140809222030_add_user_table.rb
@@ -1,4 +1,4 @@
-class AddUserTable < ActiveRecord::Migration
+class AddUserTable < ActiveRecord::Migration[4.2]
   def change
     create_table(:fae_users) do |t|
       ## Database authenticatable

--- a/db/migrate/20140822224029_create_fae_roles.rb
+++ b/db/migrate/20140822224029_create_fae_roles.rb
@@ -1,4 +1,4 @@
-class CreateFaeRoles < ActiveRecord::Migration
+class CreateFaeRoles < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_roles do |t|
       t.string :name

--- a/db/migrate/20141008180718_create_fae_images_table.rb
+++ b/db/migrate/20141008180718_create_fae_images_table.rb
@@ -1,4 +1,4 @@
-class CreateFaeImagesTable < ActiveRecord::Migration
+class CreateFaeImagesTable < ActiveRecord::Migration[4.2]
   def change
     create_table(:fae_images) do |t|
       t.string :name

--- a/db/migrate/20141017194616_create_fae_options.rb
+++ b/db/migrate/20141017194616_create_fae_options.rb
@@ -1,4 +1,4 @@
-class CreateFaeOptions < ActiveRecord::Migration
+class CreateFaeOptions < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_options do |t|
       t.string :title

--- a/db/migrate/20141021181327_create_fae_files.rb
+++ b/db/migrate/20141021181327_create_fae_files.rb
@@ -1,4 +1,4 @@
-class CreateFaeFiles < ActiveRecord::Migration
+class CreateFaeFiles < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_files do |t|
       t.string :name

--- a/db/migrate/20141021183047_create_fae_text_areas.rb
+++ b/db/migrate/20141021183047_create_fae_text_areas.rb
@@ -1,4 +1,4 @@
-class CreateFaeTextAreas < ActiveRecord::Migration
+class CreateFaeTextAreas < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_text_areas do |t|
       t.string :label

--- a/db/migrate/20141021184311_create_fae_pages.rb
+++ b/db/migrate/20141021184311_create_fae_pages.rb
@@ -1,4 +1,4 @@
-class CreateFaePages < ActiveRecord::Migration
+class CreateFaePages < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_static_pages do |t|
       t.string :title

--- a/db/migrate/20141105214814_create_fae_text_fields.rb
+++ b/db/migrate/20141105214814_create_fae_text_fields.rb
@@ -1,4 +1,4 @@
-class CreateFaeTextFields < ActiveRecord::Migration
+class CreateFaeTextFields < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_text_fields do |t|
       t.references :contentable, polymorphic: true, index: true

--- a/db/migrate/20150930224821_create_fae_changes.rb
+++ b/db/migrate/20150930224821_create_fae_changes.rb
@@ -1,4 +1,4 @@
-class CreateFaeChanges < ActiveRecord::Migration
+class CreateFaeChanges < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_changes do |t|
       t.integer :changeable_id


### PR DESCRIPTION
Hi there,

I got an error when I executed the `bin/rails g fae:install` command.
I saw the following logs.

```ruby
      insert  config/routes.rb
      create  lib/tasks/fae_tasks.rake
      create  app/assets/stylesheets/fae.scss
      create  app/assets/javascripts/fae.js
      create  app/models/concerns/fae/navigation_concern.rb
      create  app/models/concerns/fae/authorization_concern.rb
      create  config/initializers/fae.rb
      insert  config/initializers/fae.rb
      create  config/initializers/judge.rb
        rake  fae:install:migrations
Copied migration 20170530113245_add_user_table.fae.rb from fae
Copied migration 20170530113246_create_fae_roles.fae.rb from fae
Copied migration 20170530113247_create_fae_images_table.fae.rb from fae
Copied migration 20170530113248_create_fae_options.fae.rb from fae
Copied migration 20170530113249_create_fae_files.fae.rb from fae
Copied migration 20170530113250_create_fae_text_areas.fae.rb from fae
Copied migration 20170530113251_create_fae_pages.fae.rb from fae
Copied migration 20170530113252_create_fae_text_fields.fae.rb from fae
Copied migration 20170530113253_create_fae_changes.fae.rb from fae
        rake  db:migrate
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class AddUserTable < ActiveRecord::Migration[4.2]
vendor/bundle/ruby/2.4.0/gems/activerecord-5.1.1/lib/active_record/migration.rb:525:in `inherited'
db/migrate/20170530113245_add_user_table.fae.rb:2:in `<top (required)>'
```

This PR will with this problem.

## My development environments

Ruby 2.4.1
Rails 5.1.1
PostgreSQL

## Steps to reproduce

Make a new Rails 5.1 project.
Create a database.
Add `gem 'fae-rails'` to your Gemfile
Run `bundle install`
Run `bin/rails g fae:install`