### PR TITLE
adds Rails version restriction to Quickstart quide

### DIFF
--- a/docs/quickstart-guide.md
+++ b/docs/quickstart-guide.md
@@ -1,5 +1,13 @@
 # Quickstart Guide
 
+This installation guide is for a Rails 5.0 application. We are currently working on support for Rails 5.1.
+
+If you are starting from scratch, install Rails via:
+
+```bash
+gem install rails -v '~> 5.0.0'
+```
+
 ## Installation
 
 1) Add the gem to your `Gemfile` and run `bundle install`.


### PR DESCRIPTION
Adds note about Rails 5.1 in quickstar guide. Related to #255 