### PR TITLE
initial patch for acts_as_list screwing up cloning

### DIFF
--- a/app/controllers/concerns/fae/cloneable.rb
+++ b/app/controllers/concerns/fae/cloneable.rb
@@ -62,7 +62,7 @@ module Fae
 
     def clone_has_many_relationships(association)
       if @item.send(association).present?
-        @item.send(association).each do |record|
+        @item.send(association).reverse.each do |record|
           new_record = association.to_s.classify.constantize.find_by_id(record.id).dup
           new_record.send("#{@klass_singular}_id" + '=', @cloned_item.id) if new_record.send("#{@klass_singular}_id").present?
           # check if associations have unique attributes
@@ -77,7 +77,7 @@ module Fae
 
     def clone_join_relationships(object)
       if @item.send(object.to_sym).present?
-        @item.send(object.to_sym).each do |record|
+        @item.send(object.to_sym).reverse.each do |record|
           copied_join = object.classify.constantize.find_by_id(record.id).dup
           copied_join.send("#{@klass_singular}_id" + '=', @cloned_item.id)
           @cloned_item.send(object.to_sym) << copied_join

--- a/spec/dummy/app/models/aroma.rb
+++ b/spec/dummy/app/models/aroma.rb
@@ -4,6 +4,7 @@ class Aroma < ActiveRecord::Base
   belongs_to :release
   has_many :cats
 
+  acts_as_list add_new_at: :top, scope: :release
   default_scope { order(:position) }
 
   has_one :image, as: :imageable, class_name: '::Fae::Image', dependent: :destroy


### PR DESCRIPTION
acts_as_list is not playing well with `dup` 

essentially the end result is the new duped set of items ends up in reverse order from it's original state in the object that was cloned. so reversing the set prior to the looped-dup operation prevents this from happening.

i don't think reversing the set will have any unforeseen consequences on ordering because our objects are alway ordered by _some attribute_, be it a date col, position, name, etc

one thing that worries me is the condition i found the aroma.rb model in the dummy app - it uses user ranking but did not have acts_as_list called in the model class. in cases like this, the reversing of the set prior to duping will have the opposite effect. perhaps this isn't a worry because normally we define position attrs in the scaffold generator and that injects acts_as_list into the model?

