### PR TITLE
Fix Rails 5.1 deprecation warnings

### DIFF
--- a/app/models/concerns/fae/trackable.rb
+++ b/app/models/concerns/fae/trackable.rb
@@ -9,7 +9,7 @@ module Fae
 
       has_many :tracked_changes, -> { order(id: :desc) },
         as: :changeable,
-        class_name: Fae::Change
+        class_name: 'Fae::Change'
     end
 
     def fae_tracker_blacklist


### PR DESCRIPTION
Just a heads-up as it's not critical (and I know you don't support Rails 5.1 yet).

I get this when I run my tests on a Rails 5.1 project with `Fae::BaseModelConcern` included in my model.

```
DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies. Please pass the class name as a string: `has_many :tracked_changes, class_name: 'Fae::Change'` (called from include at /home/hans/projects/myproject/app/models/my_model.rb:2)
```