### PR TITLE
restore inflections initializer to default with no acronym inflection…

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,10 +1,16 @@
-ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.acronym 'LOL'
-  inflect.acronym 'PDF'
-  inflect.acronym 'SEO'
-  inflect.acronym 'CEO'
-  inflect.acronym 'SKU'
-  inflect.acronym 'URL'
-  inflect.acronym 'AVA'
-  inflect.acronym 'CTA'
-end
+# Be sure to restart your server when you modify this file.
+
+# Add new inflection rules using the following format. Inflections
+# are locale specific, and you may define rules for as many different
+# locales as you wish. All of these examples are active by default:
+# ActiveSupport::Inflector.inflections(:en) do |inflect|
+#   inflect.plural /^(ox)$/i, '\1en'
+#   inflect.singular /^(ox)en/i, '\1'
+#   inflect.irregular 'person', 'people'
+#   inflect.uncountable %w( fish sheep )
+# end
+
+# These inflection rules are supported but not enabled by default:
+# ActiveSupport::Inflector.inflections(:en) do |inflect|
+#   inflect.acronym 'RESTful'
+# end

--- a/spec/features/form_helpers/fae_input_spec.rb
+++ b/spec/features/form_helpers/fae_input_spec.rb
@@ -21,9 +21,7 @@ feature 'fae_input' do
     end
   end
 
-  scenario 'should capitalize acronyms in fields, and display common helper texts' do
-    expect(page).to have_content('SEO Title')
-    expect(page).to have_content('SEO Description')
+  scenario 'should display common helper texts' do
     expect(page).to have_content('Company Name | Keyword-driven description of the page section. Approx 65 characters.')
     expect(page).to have_content('Displayed in search engine results. Under 150 characters.')
   end


### PR DESCRIPTION
any existing app we have that uses class names that contain instances of these acronyms will now break because it expects these instances to be titleized in the class names, 