### PR TITLE
authorize global search results

### DIFF
--- a/app/controllers/fae/application_controller.rb
+++ b/app/controllers/fae/application_controller.rb
@@ -105,7 +105,18 @@ module Fae
     def load_and_filter_models
       # load of all models since Rails caches activerecord queries.
       Rails.application.eager_load!
-      ActiveRecord::Base.descendants.map.reject { |m| m.name['Fae::'] || !m.instance_methods.include?(:fae_display_field) || Fae.dashboard_exclusions.include?(m.name) }
+      ActiveRecord::Base.descendants.map.reject { |m| m.name['Fae::'] || !m.instance_methods.include?(:fae_display_field) || Fae.dashboard_exclusions.include?(m.name) || !authorize_model(m) }
+    end
+
+    def authorize_model(model)
+      return false if current_user.blank? || current_user.role.blank? || current_user.role.name.blank?
+
+      users_role           = current_user.role.name.downcase
+      tableized_model      = model.name.tableize
+      role_group_for_model = Fae::Authorization.access_map[tableized_model]
+
+      return true if role_group_for_model.blank? || (role_group_for_model.present? && role_group_for_model.include?(users_role))
+      false
     end
 
   end

--- a/app/controllers/fae/utilities_controller.rb
+++ b/app/controllers/fae/utilities_controller.rb
@@ -54,7 +54,25 @@ module Fae
       all_models.each do |m|
         records += m.fae_search(query)
       end
-      records
+      authorize_records(records)
+    end
+
+    def authorize_records(records)
+      users_role = current_user.role.name.downcase
+      authorized_records = []
+
+      records.each do |record|
+        tableized_model = record.class.name.tableize
+        role_group_for_model = Fae::Authorization.access_map[tableized_model]
+
+        if role_group_for_model.present?
+          authorized_records << record if role_group_for_model.include?(users_role)
+        else
+          authorized_records << record
+        end
+      end
+
+      authorized_records
     end
 
   end

--- a/app/controllers/fae/utilities_controller.rb
+++ b/app/controllers/fae/utilities_controller.rb
@@ -54,25 +54,7 @@ module Fae
       all_models.each do |m|
         records += m.fae_search(query)
       end
-      authorize_records(records)
-    end
-
-    def authorize_records(records)
-      users_role = current_user.role.name.downcase
-      authorized_records = []
-
-      records.each do |record|
-        tableized_model = record.class.name.tableize
-        role_group_for_model = Fae::Authorization.access_map[tableized_model]
-
-        if role_group_for_model.present?
-          authorized_records << record if role_group_for_model.include?(users_role)
-        else
-          authorized_records << record
-        end
-      end
-
-      authorized_records
+      records
     end
 
   end

--- a/spec/dummy/app/models/concerns/fae/authorization_concern.rb
+++ b/spec/dummy/app/models/concerns/fae/authorization_concern.rb
@@ -20,7 +20,7 @@ module Fae
       # }
       def access_map
         {
-          'people' => ['super admin', 'admin'],
+          'people' => ['super admin', 'admin', 'user'],
           'locations' => ['super admin', 'admin'],
           'validation_testers' => ['super admin', 'admin'],
           'releases' => ['super admin', 'admin'],

--- a/spec/dummy/app/models/concerns/fae/authorization_concern.rb
+++ b/spec/dummy/app/models/concerns/fae/authorization_concern.rb
@@ -24,6 +24,7 @@ module Fae
           'locations' => ['super admin', 'admin'],
           'validation_testers' => ['super admin', 'admin'],
           'releases' => ['super admin', 'admin'],
+          'beers' => ['super admin', 'admin'],
           'selling_points' => ['super admin', 'admin'],
           'jerseys' => ['super admin', 'admin'],
           'content_blocks/about_us' => ['super admin']

--- a/spec/dummy/app/models/concerns/fae/navigation_concern.rb
+++ b/spec/dummy/app/models/concerns/fae/navigation_concern.rb
@@ -20,6 +20,7 @@ module Fae
           item('Locations', path: admin_locations_path),
           item('Validation Testers', path: admin_validation_testers_path),
         ]),
+        item('Beers', path: admin_beers_path),
         item('Pages', path: fae.pages_path, subitems: [
           item('Home', path: fae.edit_content_block_path('home')),
           item('Contact Us', path: fae.edit_content_block_path('contact_us')),

--- a/spec/features/global_search_spec.rb
+++ b/spec/features/global_search_spec.rb
@@ -34,4 +34,34 @@ feature 'Global search' do
     end
   end
 
+  # see dummy app's authorization concern for auth mapping used here
+  scenario "search results get authorized", js: true do
+    FactoryGirl.create(:release, name: '2012 Chardonnay')
+    FactoryGirl.create(:person, name: 'Rupert')
+
+    user_login
+    visit fae_path
+
+    within('#js-utility-search') do
+      # user hovers on the search icon
+      first('a').hover
+
+      # doesn't see unauthorized stuff
+      # object
+      fill_in('js-global-search', with: 'char')
+      expect(page).to_not have_content('2012 Chardonnay')
+      # page
+      fill_in('js-global-search', with: 'abou')
+      expect(page).to_not have_content('About Us')
+
+      # sees authorized stuff
+      # object
+      fill_in('js-global-search', with: 'rup')
+      expect(page).to have_content('Rupert')
+      # page
+      fill_in('js-global-search', with: 'home')
+      expect(page).to have_content('Home')
+    end
+  end
+
 end

--- a/spec/requests/nav_spec.rb
+++ b/spec/requests/nav_spec.rb
@@ -54,11 +54,11 @@ describe 'Global nav' do
       expect(response.body).to_not include('<a href="/admin/root">Root Settings</a>')
     end
 
-    it 'should not display events top nav item' do
+    it 'should not display beers top nav item' do
       user_login
       get fae_path
 
-      expect(response.body).to_not include('<a href="#">Events</a>')
+      expect(response.body).to_not include('<a href="#">Beers</a>')
     end
   end
 


### PR DESCRIPTION
ended up having to put the auth check on the `records` set instead of trying to do it on the `all_models` collection because it won't work with content blocks on that level.