### PR TITLE
initial pass for asset cloning

### DIFF
--- a/app/controllers/concerns/fae/asset_cloner.rb
+++ b/app/controllers/concerns/fae/asset_cloner.rb
@@ -1,0 +1,46 @@
+module Fae
+  class AssetCloner
+    NoFileForOriginalResource  = Class.new(StandardError)
+    UnknownStorage             = Class.new(StandardError)
+
+    attr_reader :original_resource, :resource, :mount_point
+
+    def initialize(original_resource, resource, mount_point)
+      @mount_point       = mount_point.to_sym
+      @original_resource = original_resource
+      @resource          = resource
+    end
+
+    def set_file
+      if have_file?
+        case original_resource_mounter.send(:storage).class.name
+        when 'CarrierWave::Storage::File'
+          set_file_for_local_storage
+        when 'CarrierWave::Storage::Fog', 'CarrierWave::Storage::AWS'
+          set_file_for_remote_storage
+        else
+          raise UnknownStorage
+        end
+      else
+        raise NoFileForOriginalResource
+      end
+    end
+
+    def have_file?
+      original_resource_mounter.file.present? || original_resource_mounter.url
+    end
+
+    def set_file_for_remote_storage
+      resource.send(:"remote_#{mount_point.to_s}_url=", original_resource_mounter.url)
+    end
+
+    def set_file_for_local_storage
+      resource.send(:"#{mount_point.to_s}=", ::File.open(original_resource_mounter.file.file))
+    end
+
+    def original_resource_mounter
+      original_resource.send(mount_point)
+    end
+
+  end
+end

--- a/app/controllers/concerns/fae/cloneable.rb
+++ b/app/controllers/concerns/fae/cloneable.rb
@@ -63,7 +63,7 @@ module Fae
         if ['::Fae::Image','::Fae::File'].include?(type.options[:class_name])
           new_record.send("#{type.options[:as]}_id" + '=', @cloned_item.id) if new_record.send("#{type.options[:as]}_id").present?
           new_record.send("#{type.options[:as]}_type" + '=', @cloned_item.class.name) if new_record.send("#{type.options[:as]}_type").present?
-          Fae::AssetCloner.new(old_record, new_record, :asset).set_file if old_record.asset.url.present?
+          Fae::AssetCloner.new(old_record, new_record, :asset).set_file if old_record.asset.present? && old_record.asset.url.present?
           new_record.save
         else
           new_record.send("#{@klass_singular}_id" + '=', @cloned_item.id) if new_record.send("#{@klass_singular}_id").present?

--- a/app/controllers/concerns/fae/cloneable.rb
+++ b/app/controllers/concerns/fae/cloneable.rb
@@ -46,6 +46,7 @@ module Fae
       associations_for_cloning.each do |association|
         type = @klass.reflect_on_association(association)
         through_record = type.through_reflection
+
         if through_record.present?
           clone_join_relationships(through_record.plural_name)
         else

--- a/app/controllers/concerns/fae/cloneable.rb
+++ b/app/controllers/concerns/fae/cloneable.rb
@@ -46,18 +46,32 @@ module Fae
       associations_for_cloning.each do |association|
         type = @klass.reflect_on_association(association)
         through_record = type.through_reflection
-
         if through_record.present?
           clone_join_relationships(through_record.plural_name)
         else
-          clone_has_one_relationship(association) if type.macro == :has_one
+          clone_has_one_relationship(association,type) if type.macro == :has_one
           clone_has_many_relationships(association) if type.macro == :has_many
         end
       end
     end
 
-    def clone_has_one_relationship(association)
-      @cloned_item.send(association) << @item.send(association).dup if @item.send(association).present?
+    def clone_has_one_relationship(association,type)
+      old_record = @item.send(association)
+
+      if old_record.present?
+        new_record = old_record.dup
+        if ['::Fae::Image','::Fae::File'].include?(type.options[:class_name])
+          new_record.send("#{type.options[:as]}_id" + '=', @cloned_item.id) if new_record.send("#{type.options[:as]}_id").present?
+          new_record.send("#{type.options[:as]}_type" + '=', @cloned_item.class.name) if new_record.send("#{type.options[:as]}_type").present?
+          Fae::AssetCloner.new(old_record, new_record, :asset).set_file if old_record.asset.url.present?
+          new_record.save
+        else
+          new_record.send("#{@klass_singular}_id" + '=', @cloned_item.id) if new_record.send("#{@klass_singular}_id").present?
+        end
+        new_record.attributes.each do |attribute, value|
+          rename_unique_attribute(new_record, attribute, value) if attr_is_unique?(new_record, attribute.first)
+        end
+      end
     end
 
     def clone_has_many_relationships(association)

--- a/spec/dummy/app/controllers/admin/releases_controller.rb
+++ b/spec/dummy/app/controllers/admin/releases_controller.rb
@@ -13,7 +13,7 @@ class Admin::ReleasesController < Fae::BaseController
   end
 
   def associations_for_cloning
-    [:aromas, :events]
+    [:aromas, :events, :bottle_shot, :label_pdf]
   end
 
   def use_pagination

--- a/spec/requests/cloning_assets_spec.rb
+++ b/spec/requests/cloning_assets_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'cloning assets' do
+
+  it 'should clone fae assets' do
+
+    release = FactoryGirl.create(:release, name: 'Ima Release')
+    bottle_shot = FactoryGirl.create(:fae_image, imageable_type: 'Release', imageable_id: release.id, attached_as: 'bottle_shot')
+    label_pdf = FactoryGirl.create(:fae_file, fileable_type: 'Release', fileable_id: release.id, attached_as: 'label_pdf')
+
+    admin_login
+    post admin_releases_path(from_existing: 1)
+
+    cloned_release = Release.find_by_name('Ima Release-2')
+
+    expect(cloned_release.bottle_shot).to_not eq(bottle_shot)
+    expect(cloned_release.bottle_shot.asset.file.filename).to eq(bottle_shot.asset.file.filename)
+
+    expect(cloned_release.label_pdf).to_not eq(label_pdf)
+    expect(cloned_release.label_pdf.asset.file.filename).to eq(label_pdf.asset.file.filename)
+
+  end
+
+end

--- a/spec/requests/cloning_assets_spec.rb
+++ b/spec/requests/cloning_assets_spec.rb
@@ -9,7 +9,7 @@ describe 'cloning assets' do
     label_pdf = FactoryGirl.create(:fae_file, fileable_type: 'Release', fileable_id: release.id, attached_as: 'label_pdf')
 
     admin_login
-    post admin_releases_path(from_existing: 1)
+    post admin_releases_path(from_existing: release.id)
 
     cloned_release = Release.find_by_name('Ima Release-2')
 


### PR DESCRIPTION
1) rip apart asset_cloner.rb to your heart's content - it works well as-is though.

2) the existing cloning implementation did not work for has_one's, and there were no tests for has_one's cloning. during this i realized has_one's are basically never used in any of our apps outside of file attachments, so i can see why that was overlooked.

3) had a *really* difficult time getting the fae file factories to work in the context of a capybara feature spec (where the rest of the cloning tests are).  after hours of wheel-spinning i threw in the towel and moved the asset cloning spec into a request spec and it works without issue there.