### PR TITLE
Refs #60171 - Adds a helpful actions to multiselects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - enhancements
     + Add support for HTML wysiwyg editor with images upload
     + \#66263 Nested table H3s have been promoted to H2s to increase their visiblity on long detail pages
+    + \#60171 Add "Select All" and "Deselect All" options to multiselect dropdowns
 - bugs
 
 ## 1.5.1

--- a/app/assets/javascripts/fae/form/_form.js
+++ b/app/assets/javascripts/fae/form/_form.js
@@ -7,6 +7,9 @@
  */
 Fae.form = {
   ready: function() {
+    // Mutate DOM to support two column labels for all standard inputs
+    this.makeTwoColumnLabels();
+
     this.dates.init();
     this.text.init();
     this.select.init();
@@ -23,9 +26,6 @@ Fae.form = {
       $('.input.file').fileinputer();
     }
 
-    // Mutate DOM to support two column labels for all standard inputs
-    this.makeTwoColumnLabels();
-
     // make all the hint areas
     $('.hint').hinter();
   },
@@ -33,9 +33,10 @@ Fae.form = {
   makeTwoColumnLabels: function() {
     $('.input label').each(function() {
       var $element = $(this);
+      var has_no_helper_text = false;
 
       // Bail if we cannot find any helper_text
-      if (!$element.find('.helper_text').length) { return; }
+      if (!$element.find('.helper_text').length) { has_no_helper_text = true; }
 
       // If present, get all DOM nodes w/ contents(), but ignore the .helper_text
       var label_inner = $element.contents().filter(function() {
@@ -52,6 +53,10 @@ Fae.form = {
 
       // Ensure that we mark this input as having two column label support
       $element.addClass('label--two_col');
+
+      if (has_no_helper_text) {
+        $element.addClass('has_no_helper_text');
+      }
     });
   }
 };

--- a/app/assets/javascripts/fae/form/_form.js
+++ b/app/assets/javascripts/fae/form/_form.js
@@ -33,10 +33,11 @@ Fae.form = {
   makeTwoColumnLabels: function() {
     $('.input label').each(function() {
       var $element = $(this);
-      var has_no_helper_text = false;
 
       // Bail if we cannot find any helper_text
-      if (!$element.find('.helper_text').length) { has_no_helper_text = true; }
+      if (!$element.find('.helper_text').length) {
+        $element.addClass('has_no_helper_text');
+      }
 
       // If present, get all DOM nodes w/ contents(), but ignore the .helper_text
       var label_inner = $element.contents().filter(function() {
@@ -53,10 +54,6 @@ Fae.form = {
 
       // Ensure that we mark this input as having two column label support
       $element.addClass('label--two_col');
-
-      if (has_no_helper_text) {
-        $element.addClass('has_no_helper_text');
-      }
     });
   }
 };

--- a/app/assets/javascripts/fae/form/inputs/_select.js
+++ b/app/assets/javascripts/fae/form/inputs/_select.js
@@ -9,6 +9,7 @@ Fae.form.select = {
 
   init: function() {
     this.multiselectOrChosen();
+    this.multiselectChosenActions();
   },
 
   /**
@@ -55,6 +56,107 @@ Fae.form.select = {
 
       }
     });
+  },
+
+  /**
+   * Adds functionality for Select All and Deselect All multiselect options
+   */
+  multiselectChosenActions: function() {
+    var query_input_select = '.input.select';
+    // Ignore select elements with .multiselect classes, because these are used for a different widget
+    var query_eligible_multiselects = query_input_select + ' select[multiple]:not(.multiselect)';
+    var select_all_value = 'multiselect_action-select_all';
+
+    var $eligible_multiselects = $(query_eligible_multiselects);
+    $eligible_multiselects.each(function(index, element) {
+      var $element = $(element);
+      var $options = $element.find('option');
+      var $chosen = $('#' + $element.attr('id') + '_chosen');
+
+      // Ignore if select doesn't have enough options to warrant additional actions
+      if ($options.length < 2) {
+        return;
+      }
+
+      // Insert Select All btn above select
+      var $label = $element.closest(query_input_select).find('label:first');
+      var $deselect_all_action = $('<div/>', {
+        class: 'multiselect-action_wrap',
+        html: $('<div/>', {
+          class: 'js-multiselect-action-deselect_all multiselect-action-deselect_all multiselect-action',
+          html: $('<a/>', {
+            href: '#',
+            tabindex: '-1',
+            html: 'Deselect&nbsp;All'
+          })
+        })
+      });
+
+      // Add actions to wraper
+      $deselect_all_action.insertAfter($chosen);
+
+      // Add special "Select All" option and notify Chosen of new option
+      addSelectAllOption($element)
+
+      // Mark label wrapper as having multiselect actions for styling
+      $label.addClass('has-multiselect-actions');
+
+      // Enable or disable multiselect actions based on select state
+      setAbilities($element);
+    });
+
+    // Watch select for changes and add, remove, or carry out Select All option as needed
+    $('#js-main-content').on('change', query_eligible_multiselects, function(e) {
+      var $element = $(e.currentTarget);
+
+      // Set state of possible actions
+      setAbilities($element);
+
+      // Intercept selections of the Select All option and select all other options.
+      var requesting_select_all = $element.val() && $element.val().indexOf(select_all_value) !== -1;
+      if (requesting_select_all) {
+        setAllOptionsSelected($element, true);
+      }
+    });
+
+    // Handle click on Deselect All btn
+    $('#js-main-content').on('click', '.js-multiselect-action-deselect_all', function(e) {
+      e.preventDefault();
+      setAllOptionsSelected(this, false);
+    });
+
+    // Enable or disable actions based on state
+    function setAbilities($element) {
+      var $deselect_all = $('.js-multiselect-action-deselect_all');
+
+      // Only allow deselects when options are selected
+      if ($element.find('option:selected').length) {
+        $deselect_all.show();
+      } else {
+        $deselect_all.hide();
+      }
+    }
+
+    // Add special "Select All" option
+    function addSelectAllOption($element) {
+      var $select_all_option = $('<option />', {
+        value: select_all_value,
+        text: 'SELECT ALL'
+      });
+      $select_all_option.prependTo($element);
+      $element.trigger('chosen:updated');
+    }
+
+    // Mark all options as selected or not
+    function setAllOptionsSelected(select, state) {
+      var $select = $(select).closest(query_input_select).find('select');
+      // Set selection state per provided state boolean
+      $select.find('option').prop('selected', state);
+      // Always ignore magic Select All btn
+      $select.find('option[value="' + select_all_value + '"]').prop('selected', false);
+      $select.trigger('chosen:updated');
+      $select.trigger('change');
+    }
   }
 
 };

--- a/app/assets/stylesheets/fae/modules/forms/_label.scss
+++ b/app/assets/stylesheets/fae/modules/forms/_label.scss
@@ -37,4 +37,21 @@ label {
       padding-top: 1px;
     }
   }
+
+  &.has-multiselect-actions {
+    .multiselect-action {
+      a {
+        font-weight: normal;
+      }
+    }
+
+    // Ensure helper text fills space between primary label & multiselect actions
+    h6 {
+      flex-grow: 1;
+    }
+  }
+
+  &.has_no_helper_text {
+    justify-content: space-between;
+  }
 }

--- a/app/assets/stylesheets/fae/modules/forms/_select.scss
+++ b/app/assets/stylesheets/fae/modules/forms/_select.scss
@@ -68,8 +68,9 @@
 .chosen-container-multi {
   max-width: 515px;
   min-width: 223px;
+
   // overriding the inline js chosen makes
-  width: 90% !important;
+  width: 100% !important;
 
   &.chosen-container-active {
     .chosen-choices {
@@ -126,6 +127,24 @@
 .chosen-container-multi.chosen-with-drop:not(.chosen-drop-up) {
   .chosen-choices {
     border-bottom: none;
+  }
+}
+
+.multiselect-action_wrap {
+  font-size: 13px;
+  line-height: 1.3;
+  margin-top: 10px;
+
+  .multiselect-action {
+    display: inline-block;
+    margin: 0 10px 10px 0;
+    padding-right: 13px;
+    border-right: 1px solid $c-mid-grey;
+
+    &:last-of-type {
+      padding-right: 0;
+      border-right: none;
+    }
   }
 }
 

--- a/app/assets/stylesheets/fae/modules/forms/_text.scss
+++ b/app/assets/stylesheets/fae/modules/forms/_text.scss
@@ -9,6 +9,7 @@
   &.string,
   &.tel,
   &.text,
+  &.select,
   > .label {
     max-width: 515px;
 

--- a/spec/dummy/app/views/admin/releases/_form.html.slim
+++ b/spec/dummy/app/views/admin/releases/_form.html.slim
@@ -64,7 +64,7 @@
 
     = fae_pulldown f, :wine, size: 'short', helper_text: 'pulldown short', collection: Wine.order(:name_en), label_method: :name_en
 
-    = fae_multiselect f, :acclaims, label_method: :publication, helper_text: 'mutliselect'
+    = fae_multiselect f, :acclaims, label_method: :publication, helper_text: 'multiselect with a long helper description to ensure that the multiselect actions can coexist peacefully'
 
     = fae_multiselect f, :selling_points, two_pane: true, helper_text: 'two-pane mutliselect'
 


### PR DESCRIPTION
**Internal issue:** https://issues.afinedevelopment.com/issues/60171

* Adds "SELECT ALL" as an option to multiselect fields.
* When a multiselect field has an item is selected, "Deselect All" now appears below the field.

Can be verified [on stage](http://stage.fae.afinedevelopment.com/admin/releases/3/edit#associations) — check the Acclaims multiselect.