### PR TITLE
Documentation for Language, Heroku, and Files

### DIFF
--- a/docs/features/multi_language.md
+++ b/docs/features/multi_language.md
@@ -94,3 +94,40 @@ end
 ```
 
 Add `languages: true` to the page's `fae/shared/form_header` partial to utilize Fae's language switcher.
+
+## In the Application
+
+To display the right translation, Rails needs to interpret the requested locale. This can be done with a simple ApplicationController method:
+
+```ruby
+# app/controllers/application_controller
+class ApplicationController < ActionController::Base
+  before_action :set_locale
+
+  private
+    def set_locale
+      I18n.locale = params[:locale] || request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first.presence || I18n.default_locale
+    end
+end
+```
+
+The above assumes that your routes support a `locale` parameter:
+
+```ruby
+# config/routes.rb
+scope '(:locale)', locale: /en|zh/ do
+  get '/' => 'pages#home', as: 'home' # / or /zh
+  get '/about' => 'pages#about', as: 'about' # /about or /zh/about
+end
+```
+
+For URL schemes that require a language locale to always be present, a separate method can be added beneath `private` in the ApplicationController:
+
+```ruby
+# Forces locale to appear in the URL, even if the request locale matches the default locale
+def default_url_options(options={})
+  {locale: I18n.locale }
+end
+```
+
+The attribute can then be retrieved normally (i.e. `@item.name` will render `@item.name_en` if `I18n.locale` is `:en`).

--- a/docs/helpers/partials.md
+++ b/docs/helpers/partials.md
@@ -11,8 +11,8 @@
 
 ## Index Header
 
-```ruby
-index_header
+```slim
+== render 'fae/shared/index_header'
 ```
 
 Displays page title, add button, and flash messages.
@@ -26,22 +26,18 @@ Displays page title, add button, and flash messages.
 | csv | boolean | false | adds export to csv button |
 | breadcrumbs | boolean | true | display breadcrumb navigation before title |
 
-**Examples**
+### Examples
 
-Standard implementation
-```ruby
-render 'fae/shared/index_header'
-```
+#### Custom header
 
-Custom header
-```ruby
-render 'fae/shared/index_header', title: 'Something Entirely Different', new_button: false, csv: true
+```slim
+== render 'fae/shared/index_header', title: 'Something Entirely Different', new_button: false, csv: true
 ```
 
 ## Form Header
 
 ```ruby
-form_header
+== render 'fae/shared/form_header', header: @klass_name
 ```
 
 ![Form header](https://raw.githubusercontent.com/wearefine/fae/master/docs/images/form_header.png)
@@ -57,6 +53,8 @@ Displays breadcrumb links and form title.
 | cloneable | boolean | false | includes Clone button |
 | clone_button_text | string | 'Clone' | clone button text |
 | subnav | Array<String> | [] | generates "jump to" anchor links for long forms |
+
+### With subnav
 
 If `subnav` is supplied, sections within the form must include IDs matching the [parameterized](http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-parameterize) items. Note that `parameterize` will use `_` as a separator.
 
@@ -75,15 +73,8 @@ section.content#recent_changes
 
 To separate name and ID selector, pass an Array instead of a String.
 
-```ruby
+```slim
 - subnav_array = ['SEO', 'Attributes', ['Images', 'images_table']]
-```
-
-**Examples**
-
-Standard implementation
-```ruby
-render 'fae/shared/form_header', header: @item, subnav: ['SEO', 'Image Gallery', 'Recent Changes']
 ```
 
 ## Form Buttons
@@ -115,7 +106,7 @@ render 'fae/shared/form_buttons', save_button_text: 'Yes!', cancel_button_text: 
 ## Nested Table
 
 ```ruby
-nested_table
+== render 'fae/shared/nested_table'
 ```
 
 The nested table works in tandem with a nested model, typically created by the nested scaffold generator, to display a nested ajax form for creating associated items in the edit form.
@@ -137,16 +128,16 @@ The nested_table should go after the main form ends and should only be placed on
 | helper_text | string | '' | the h6 directly above the nested table and below the tite, which is used to provide the user with some helper_text to describe the context |
 | new_path | string | "new_#{fae_path}_#{assoc_name_singular}_path" | the path that the application will hit when creating a new object inside the nested table, which is used to provide the user with the ability to pass in some params |
 
-***Example**
+### Examples
 
-* cols option now accepts hashes for custom titles, using attr: and title:
+#### Custom titles in `cols`
+
 ```ruby
 cols: [{ attr: :name, title: 'What did you call me?' }, :image, :title]
 ```
 
 You may also pass in custom columns, like an association's count by first defining a method on the model, then passing it in to the cols option.
 
-**Example**
 ```ruby
 def cat_size
   cats.size.to_s
@@ -155,7 +146,7 @@ end
 cols: [{ attr: :cat_size, title: 'Kitten Count' }]
 ```
 
-**Examples**
+#### All options on an `edit` page
 
 Full Slim implementation with section wrapper and edit page conditional
 ```slim
@@ -207,8 +198,8 @@ Add the [nested table partial](helpers.md#nested_table) to the parent form. This
 
 ## Recent Changes
 
-```ruby
-recent_changes
+```slim
+== render 'fae/shared/recent_changes'
 ```
 
 ![Recent changes](https://raw.githubusercontent.com/wearefine/fae/master/docs/images/recent_changes.png)
@@ -217,14 +208,10 @@ Displays recent changes to an object as logged by the change tracker in a table.
 
 This partial is best placed at the bottom of the form and will automatically hide itself in create forms, where there wouldn't be changes to display.
 
-**Examples**
+### Examples
 
-Standard implementation
-```ruby
-= render 'fae/shared/recent_changes'
-```
+#### Add it to the form nav
 
-Optionally, you can add a link to it in the form nav:
 ```slim
 = render 'fae/shared/form_header', ..., subnav: [...,  'Recent Changes']
 ```

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -91,3 +91,7 @@ If this returns a `ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  r
 ```bash
 heroku run rake db:migrate
 ```
+
+**Assets**
+
+Heroku [does not store assets](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem). Although this is not officially supported by Fae, it is possible to [https://github.com/wearefine/fae/issues/324#issuecomment-334578748](store assets uploaded to Fae with S3).

--- a/docs/tutorials/image_and_files.md
+++ b/docs/tutorials/image_and_files.md
@@ -145,9 +145,6 @@ fae_file_form
 | helper_text   | string | | the uploader's helper text|
 | required      | boolean | false | adds required validation to the uploader |
 
-image_label: nil, alt_label: nil, caption_label: nil, omit: nil, show_thumb: nil, required: nil, helper_text: nil, alt_helper_text: nil, caption_helper_text: nil
-
-
 **Examples**
 
 ```ruby


### PR DESCRIPTION
Adds documentation to incorporate the multi language support on the front-end, links to that [one issue about using S3](https://github.com/wearefine/fae/issues/324#issuecomment-334578748), and cleans up the docs for `fae_file_form`.