### PR TITLE
#70630 - show action should return a 404 by default

### DIFF
--- a/app/controllers/fae/base_controller.rb
+++ b/app/controllers/fae/base_controller.rb
@@ -71,6 +71,11 @@ module Fae
       render :index, layout: false
     end
 
+    def show
+      # show action is hidden by default, override as needed
+      show_404
+    end
+
   private
 
     def set_class_variables(class_name = nil)

--- a/spec/requests/releases_spec.rb
+++ b/spec/requests/releases_spec.rb
@@ -57,3 +57,15 @@ describe 'releases#create' do
   end
 
 end
+
+describe 'releases#show' do
+
+  it 'should return not found' do
+    release = FactoryGirl.create(:release)
+    admin_login
+    get admin_release_path(release)
+
+    expect(response.status).to eq(404)
+  end
+
+end


### PR DESCRIPTION
We don't provide a show action in `Fae::BaseController`, so let's return a 404 instead of an error. Users can override show action per resource as needed.