### PR TITLE
Fix Rails migrations

### DIFF
--- a/db/migrate/20140809222030_add_user_table.rb
+++ b/db/migrate/20140809222030_add_user_table.rb
@@ -1,4 +1,4 @@
-class AddUserTable < ActiveRecord::Migration
+class AddUserTable < ActiveRecord::Migration[4.2]
   def change
     create_table(:fae_users) do |t|
       ## Database authenticatable

--- a/db/migrate/20140822224029_create_fae_roles.rb
+++ b/db/migrate/20140822224029_create_fae_roles.rb
@@ -1,4 +1,4 @@
-class CreateFaeRoles < ActiveRecord::Migration
+class CreateFaeRoles < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_roles do |t|
       t.string :name

--- a/db/migrate/20141008180718_create_fae_images_table.rb
+++ b/db/migrate/20141008180718_create_fae_images_table.rb
@@ -1,4 +1,4 @@
-class CreateFaeImagesTable < ActiveRecord::Migration
+class CreateFaeImagesTable < ActiveRecord::Migration[4.2]
   def change
     create_table(:fae_images) do |t|
       t.string :name

--- a/db/migrate/20141017194616_create_fae_options.rb
+++ b/db/migrate/20141017194616_create_fae_options.rb
@@ -1,4 +1,4 @@
-class CreateFaeOptions < ActiveRecord::Migration
+class CreateFaeOptions < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_options do |t|
       t.string :title

--- a/db/migrate/20141021181327_create_fae_files.rb
+++ b/db/migrate/20141021181327_create_fae_files.rb
@@ -1,4 +1,4 @@
-class CreateFaeFiles < ActiveRecord::Migration
+class CreateFaeFiles < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_files do |t|
       t.string :name

--- a/db/migrate/20141021183047_create_fae_text_areas.rb
+++ b/db/migrate/20141021183047_create_fae_text_areas.rb
@@ -1,4 +1,4 @@
-class CreateFaeTextAreas < ActiveRecord::Migration
+class CreateFaeTextAreas < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_text_areas do |t|
       t.string :label

--- a/db/migrate/20141021184311_create_fae_pages.rb
+++ b/db/migrate/20141021184311_create_fae_pages.rb
@@ -1,4 +1,4 @@
-class CreateFaePages < ActiveRecord::Migration
+class CreateFaePages < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_static_pages do |t|
       t.string :title

--- a/db/migrate/20141105214814_create_fae_text_fields.rb
+++ b/db/migrate/20141105214814_create_fae_text_fields.rb
@@ -1,4 +1,4 @@
-class CreateFaeTextFields < ActiveRecord::Migration
+class CreateFaeTextFields < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_text_fields do |t|
       t.references :contentable, polymorphic: true, index: true

--- a/db/migrate/20150930224821_create_fae_changes.rb
+++ b/db/migrate/20150930224821_create_fae_changes.rb
@@ -1,4 +1,4 @@
-class CreateFaeChanges < ActiveRecord::Migration
+class CreateFaeChanges < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_changes do |t|
       t.integer :changeable_id


### PR DESCRIPTION
Rails 5.1 requires AR::Migration version number in the migrations, otherwise they will fail.