### PR TITLE
Doc: specify static_page association as optional

### DIFF
--- a/docs/tutorials/dynamic_relationships_to_pages.md
+++ b/docs/tutorials/dynamic_relationships_to_pages.md
@@ -30,7 +30,7 @@ end
 ```ruby
 class Promo < ActiveRecord::Base
 
-  belongs_to :static_page, class_name: 'Fae::StaticPage'
+  belongs_to :static_page, class_name: 'Fae::StaticPage', optional: true
 
 end
 


### PR DESCRIPTION
Rails 5 changed the default behavior of the `belongs_to` association, making it mandatory by default. In this case, we want it to be optional or we won't be able to save promos which are not associated with a static page.