### PR TITLE
remove test_files from gemspec

### DIFF
--- a/fae.gemspec
+++ b/fae.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
-  s.test_files = Dir['spec/**/*']
 
   # Rails dependencies
   s.add_dependency 'rails', '>= 4.1'


### PR DESCRIPTION
`test_files` are a relic of the `gem test` days and only add weight to the gem.

https://github.com/rubygems/rubygems/issues/735