### PR TITLE
allow blank labels for fae_content_form

### DIFF
--- a/app/views/fae/application/_content_form.html.slim
+++ b/app/views/fae/application/_content_form.html.slim
@@ -1,6 +1,6 @@
 ruby:
   require_locals     ['attribute', 'f'], local_assigns
-  blank_label          = !label || label == '' unless label.nil?
+  has_label            = ![false, ''].include?(local_assigns[:label])
   label              ||= attribute.to_s.titleize
   required           ||= f.object.send(attribute).is_required?(f.object.class)
   helper_text        ||= attempt_common_helper_text(attribute)
@@ -10,16 +10,21 @@ ruby:
   options            ||= {}
   input_options      ||= {}
 
-  label_adjusted = required ? '<abbr title="required">*</abbr> ' : ''
-  label_adjusted += label
-  if markdown_supported.present? || helper_text.present?
-    label_adjusted += content_tag :h6, class: 'helper_text' do
-      concat(helper_text) if helper_text.present?
-      concat(content_tag(:span, 'Markdown Supported', class: 'markdown-support')) if markdown_supported.present?
+  if has_label
+    label_adjusted = required ? '<abbr title="required">*</abbr> ' : ''
+    label_adjusted += label
+    if markdown_supported.present? || helper_text.present?
+      label_adjusted += content_tag :h6, class: 'helper_text' do
+        concat(helper_text) if helper_text.present?
+        concat(content_tag(:span, 'Markdown Supported', class: 'markdown-support')) if markdown_supported.present?
+      end
     end
+  else
+    options[:label] = false
   end
 
-  options.merge! label: label_adjusted.html_safe, hint: hint
+  options.merge! label: label_adjusted.html_safe if label_adjusted.present?
+  options.merge! hint: hint
   options.merge! input_options if (input_options.keys).any?
   options.merge! wrapper_html: {} if input_options[:wrapper_html].blank?
 
@@ -30,7 +35,6 @@ ruby:
     options[:input_html].merge! class: 'js-markdown-editor' if markdown.present?
   end
 
-  options[:label] = false if blank_label
   languages = f.object.class.fae_fields[attribute].try(:[], :languages)
 
 - if languages.present?

--- a/app/views/fae/application/_content_form.html.slim
+++ b/app/views/fae/application/_content_form.html.slim
@@ -1,5 +1,6 @@
 ruby:
   require_locals     ['attribute', 'f'], local_assigns
+  blank_label          = !label || label == '' unless label.nil?
   label              ||= attribute.to_s.titleize
   required           ||= f.object.send(attribute).is_required?(f.object.class)
   helper_text        ||= attempt_common_helper_text(attribute)
@@ -29,6 +30,7 @@ ruby:
     options[:input_html].merge! class: 'js-markdown-editor' if markdown.present?
   end
 
+  options[:label] = false if blank_label
   languages = f.object.class.fae_fields[attribute].try(:[], :languages)
 
 - if languages.present?

--- a/spec/dummy/app/models/home_page.rb
+++ b/spec/dummy/app/models/home_page.rb
@@ -8,7 +8,7 @@ class HomePage < Fae::StaticPage
       header: {
         type: Fae::TextField,
         validates: { presence: true }
-        },
+      },
       hero: Fae::TextField,
       email: {
         type: Fae::TextField,
@@ -21,6 +21,8 @@ class HomePage < Fae::StaticPage
           }
         },
       phone: { type: Fae::TextField },
+      cell_phone: { type: Fae::TextField },
+      work_phone: { type: Fae::TextField },
       introduction: {
         type: Fae::TextArea,
         validates: {

--- a/spec/dummy/app/views/admin/content_blocks/home.html.slim
+++ b/spec/dummy/app/views/admin/content_blocks/home.html.slim
@@ -7,6 +7,9 @@
     = fae_content_form f, :header
     = fae_content_form f, :hero
     = fae_content_form f, :email
+    = fae_content_form f, :phone
+    = fae_content_form f, :cell_phone, label: false
+    = fae_content_form f, :work_phone, label: ''
     = fae_content_form f, :introduction
     = fae_content_form f, :introduction_2, markdown: true
     = fae_content_form f, :phone, input_options: { input_html: { class: 'phone-mask' } }, helper_text: 'Numbers only, do not format', label: 'Phone #'

--- a/spec/features/form_helpers/fae_content_form_spec.rb
+++ b/spec/features/form_helpers/fae_content_form_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'fae_content_form' do
 
-  scenario 'should display content form fields, markdown class if its included, and custom input classes if they are included' do
+  scenario 'should display content form fields, markdown class, custom input classes, and allow blank labels' do
 
     admin_login
     visit fae.edit_content_block_path('home')
@@ -16,13 +16,22 @@ feature 'fae_content_form' do
 
     # input_class + markdown
     within('.home_page_introduction_2_content') do
-        expect(page).to have_selector('.js-markdown-editor')
+      expect(page).to have_selector('.js-markdown-editor')
     end
 
     # just markdown
     within('.home_page_body_content') do
-        expect(page).to have_css('.some-cool-class')
-        expect(page).to have_selector('.js-markdown-editor')
+      expect(page).to have_css('.some-cool-class')
+      expect(page).to have_selector('.js-markdown-editor')
+    end
+
+    # blank labels
+    within('.home_page_cell_phone_content') do
+      expect(page).to_not have_css('label')
+    end
+
+    within('.home_page_work_phone_content') do
+      expect(page).to_not have_css('label')
     end
   end
 

--- a/spec/models/fae/static_page_spec.rb
+++ b/spec/models/fae/static_page_spec.rb
@@ -18,11 +18,11 @@ describe Fae::StaticPage do
 
     it 'should attach only once' do
       hp = HomePage.instance
-      expect(hp.class.reflect_on_all_associations(:has_one).map(&:name)).to eq([:header, :hero, :email, :phone, :introduction, :introduction_2, :body, :hero_image, :welcome_pdf])
+      expect(hp.class.reflect_on_all_associations(:has_one).map(&:name)).to eq([:header, :hero, :email, :phone, :cell_phone, :work_phone, :introduction, :introduction_2, :body, :hero_image, :welcome_pdf])
 
       # trigger instance twice
       hp = HomePage.instance
-      expect(hp.class.reflect_on_all_associations(:has_one).map(&:name)).to eq([:header, :hero, :email, :phone, :introduction, :introduction_2, :body, :hero_image, :welcome_pdf])
+      expect(hp.class.reflect_on_all_associations(:has_one).map(&:name)).to eq([:header, :hero, :email, :phone, :cell_phone, :work_phone, :introduction, :introduction_2, :body, :hero_image, :welcome_pdf])
     end
 
     it 'should attach language associations when present' do


### PR DESCRIPTION
This is just a quick fix so I can get ticket done for a client this week. I think later on all that logic in `_content_form.html.slim` should be refactored out to be separate from the partial so that you just have to pass  an `options` in rather than every possible variable since everything is a bit dependent on each other right now and relies on a lot of conditionals.