### PR TITLE
move some fae_content_form logic out of partial

### DIFF
--- a/app/helpers/fae/view_helper.rb
+++ b/app/helpers/fae/view_helper.rb
@@ -21,8 +21,12 @@ module Fae
       render 'fae/application/file_uploader', f: f, file_name: file_name, label: label, required: required, helper_text: helper_text
     end
 
-    def fae_content_form(f, attribute, label: nil, hint: nil, helper_text: nil, markdown: nil, markdown_supported: nil, input_options: nil)
-      render 'fae/application/content_form', f: f, attribute: attribute, label: label, hint: hint, helper_text: helper_text, markdown: markdown, markdown_supported: markdown_supported, input_options: input_options
+    def fae_content_form(f, attribute, label: nil, hint: nil, helper_text: nil, markdown: false, markdown_supported: false, input_options: {})
+      required = f.object.send(attribute).is_required?(f.object.class)
+      text_options = { required: required, label: label, hint: hint, helper_text: helper_text }
+      markdown_options = { markdown: markdown, markdown_supported: markdown_supported }
+      options = Fae::FormOptions.new(attribute, text_options, markdown_options, input_options).to_hash
+      render 'fae/application/content_form', f: f, attribute: attribute, options: options
     end
 
     def fae_index_image(image, path = nil)

--- a/app/views/fae/application/_content_form.html.slim
+++ b/app/views/fae/application/_content_form.html.slim
@@ -1,45 +1,11 @@
 ruby:
-  require_locals     ['attribute', 'f'], local_assigns
-  has_label            = ![false, ''].include?(local_assigns[:label])
-  label              ||= attribute.to_s.titleize
-  required           ||= f.object.send(attribute).is_required?(f.object.class)
-  helper_text        ||= attempt_common_helper_text(attribute)
-  markdown           ||= false
-  markdown_supported ||= false
-  hint               ||= nil
-  options            ||= {}
-  input_options      ||= {}
-
-  if has_label
-    label_adjusted = required ? '<abbr title="required">*</abbr> ' : ''
-    label_adjusted += label
-    if markdown_supported.present? || helper_text.present?
-      label_adjusted += content_tag :h6, class: 'helper_text' do
-        concat(helper_text) if helper_text.present?
-        concat(content_tag(:span, 'Markdown Supported', class: 'markdown-support')) if markdown_supported.present?
-      end
-    end
-  else
-    options[:label] = false
-  end
-
-  options.merge! label: label_adjusted.html_safe if label_adjusted.present?
-  options.merge! hint: hint
-  options.merge! input_options if (input_options.keys).any?
-  options.merge! wrapper_html: {} if input_options[:wrapper_html].blank?
-
-  if options[:input_html].present? && options[:input_html][:class].present? && markdown.present?
-    options[:input_html][:class] = options[:input_html][:class] + ' js-markdown-editor'
-  elsif options[:input_html].blank?
-    options.merge! input_html: {}
-    options[:input_html].merge! class: 'js-markdown-editor' if markdown.present?
-  end
-
+  require_locals(['attribute', 'f'], local_assigns)
   languages = f.object.class.fae_fields[attribute].try(:[], :languages)
 
 - if languages.present?
   / Store original label for later gsub
   - orig_label = options[:label]
+  - label = attribute.to_s.titleize
 
   - languages.each do |lang|
     - options.deep_merge! wrapper_html: { data: { language: lang } }

--- a/lib/fae/form_options.rb
+++ b/lib/fae/form_options.rb
@@ -1,0 +1,68 @@
+module Fae
+  class FormOptions
+    include ActionView::Helpers::TagHelper
+    attr_accessor :output_buffer
+
+    def initialize(attribute, text_options, markdown_options, input_options)
+      @attribute = attribute
+      @required = text_options[:required]
+      @label = text_options[:label]
+      @hint = text_options[:hint]
+      @helper_text = text_options[:helper_text]
+      @markdown = markdown_options[:markdown]
+      @markdown_supported = markdown_options[:markdown_supported]
+      @input_options = input_options
+    end
+
+    def to_hash
+      {
+        label: set_label,
+        hint: @hint,
+        input_html: set_input_html,
+        wrapper_html: @input_options.fetch(:wrapper_html, {})
+      }
+    end
+
+    private
+
+    def set_label
+      return false if label_blank?
+      generate_label.html_safe
+    end
+
+    def label_blank?
+      @label == '' || @label == false
+    end
+
+    def generate_label
+      attribute_label = @attribute.to_s.titleize
+      label = @required ? "<abbr title='required'>*</abbr> #{attribute_label}" : attribute_label
+
+      label + content_tag(:h6, class: 'helper_text') do
+        @helper_text ||= attempt_common_helper_text
+        helper_text = content_tag(:span, @helper_text)
+        markdown_supported = content_tag(:span, 'Markdown Supported', class: 'markdown-support') if @markdown_supported.present?
+        "#{helper_text} #{markdown_supported}".html_safe
+      end
+    end
+
+    def set_input_html
+      input_html = @input_options.fetch(:input_html, {})
+      return input_html unless @markdown
+
+      @input_options[:input_html] = { class: "#{input_html[:class]} js-markdown-editor" }
+      @input_options[:input_html]
+    end
+
+    def attempt_common_helper_text
+      case @attribute
+      when :seo_title
+        'Company Name | Keyword-driven description of the page section. Approx 65 characters.'
+      when :seo_description
+        'Displayed in search engine results. Under 150 characters.'
+      else
+        ''
+      end
+    end
+  end
+end

--- a/spec/dummy/app/views/admin/content_blocks/home.html.slim
+++ b/spec/dummy/app/views/admin/content_blocks/home.html.slim
@@ -6,12 +6,12 @@
     = fae_input f, :title
     = fae_content_form f, :header
     = fae_content_form f, :hero
-    = fae_content_form f, :email
-    = fae_content_form f, :phone
+    = fae_content_form f, :email, helper_text: 'ex: fae@wearefine.com'
+    = fae_content_form f, :phone, input_options: { wrapper_html: { class: 'phone-wrapper', id: 'phone-id' } }
     = fae_content_form f, :cell_phone, label: false
     = fae_content_form f, :work_phone, label: ''
     = fae_content_form f, :introduction
-    = fae_content_form f, :introduction_2, markdown: true
+    = fae_content_form f, :introduction_2, markdown: true, markdown_supported: true, helper_text: 'helper text'
     = fae_content_form f, :phone, input_options: { input_html: { class: 'phone-mask' } }, helper_text: 'Numbers only, do not format', label: 'Phone #'
     = fae_content_form f, :body, input_options: { input_html: { class: 'some-cool-class' } }, markdown: true
     = fae_image_form f, :hero_image

--- a/spec/features/form_helpers/fae_content_form_spec.rb
+++ b/spec/features/form_helpers/fae_content_form_spec.rb
@@ -11,12 +11,15 @@ feature 'fae_content_form' do
     expect(page).to have_css('#home_page_header_attributes_content')
     expect(page).to have_css('#home_page_introduction_attributes_content')
 
-    # # input_class
+    # # input_class/wrapper_class
     expect(page).to have_css('.phone-mask')
+    expect(page).to have_selector('.phone-wrapper')
+    expect(page).to have_selector('#phone-id')
 
-    # input_class + markdown
+    # input_class + markdown + helper_text
     within('.home_page_introduction_2_content') do
       expect(page).to have_selector('.js-markdown-editor')
+      expect(page).to have_content('helper text')
     end
 
     # just markdown


### PR DESCRIPTION
There was a bit too much conditional and key/value checking and I thought I'd move some of the `fae_content_form` logic out of the partial and into a class since logic shouldn't be in a view. Let me know what you think.