### PR TITLE
Prevent breakage of the asset pipeline

### DIFF
--- a/app/assets/stylesheets/fae/application.css
+++ b/app/assets/stylesheets/fae/application.css
@@ -5,4 +5,5 @@
  *= require fae/vendor/simplemde.min
  *= require fae/vendor/trumbowyg
  *= require fae/base
+ *= require fae
  */

--- a/app/assets/stylesheets/fae/base.scss
+++ b/app/assets/stylesheets/fae/base.scss
@@ -6,9 +6,6 @@
   'globals/imports/extends'
 ;
 
-// User defined stuff
-@import 'fae';
-
 // Fonts, vendor, and root HTML tag styles
 @import
   'globals/fonts',


### PR DESCRIPTION
I want to change the way how user defined styles can be loaded from `app/assets/stylesheets/fae.scss` by providing the ability to support usage of sprockets directives within `app/assets/stylesheets/fae.scss`. The scss `@import` directive does not allow to do that.