### PR TITLE
rename translate to fae_translate to avoid conflicts - resolves #365

### DIFF
--- a/app/models/concerns/fae/base_model_concern.rb
+++ b/app/models/concerns/fae/base_model_concern.rb
@@ -69,7 +69,7 @@ module Fae
         end
       end
 
-      def translate(*attributes)
+      def fae_translate(*attributes)
         attributes.each do |attribute|
           define_method attribute.to_s do
             self.send "#{attribute}_#{I18n.locale}"

--- a/docs/features/multi_language.md
+++ b/docs/features/multi_language.md
@@ -39,13 +39,13 @@ Using Fae's generators let's quickly scaffold a model that supports multiple lan
 $ rails g fae:scaffold Person name title_en title_zh title_ja intro_en:text intro_zh:text intro_ja:text
 ```
 
-To retrieve the correct attribute on the front-end, list translated attributes **without** their language abbreviation in the `translate` class method.
+To retrieve the correct attribute on the front-end, list translated attributes **without** their language abbreviation in the `fae_translate` class method.
 
 ```ruby
 class Person < ActiveRecord::Base
   include Fae::Concerns::Models::Base
 
-  translate :name, :title, :intro
+  fae_translate :name, :title, :intro
 end
 
 # i.e. if English is the locale, @person.name == @person.name_en

--- a/docs/upgrading/index.md
+++ b/docs/upgrading/index.md
@@ -9,12 +9,9 @@
 
 # To v2.0
 
-`form_buttons` has been deprecated. Any admin still using this partial should remove `fae/shared/form_buttons` and only use [fae/shared/form_header](docs/helpers/partials.md#form-header). `form_header` still supports `save_button_text`, `cancel_button_text`, `cloneable`, and `cloneable_text` options.
-
-The `dark_hint` input option has been deprecated. The dark hint style was removed in v1.3, but now [the option](docs/helpers/form_helpers.md#global-options) has been removed. Please convert all `dark_hint` calls to `hint`.
-
-The `form_header` partial includes the errors previously rendered as a separate partial as well as the parent node markup (`header.content-header.js-content-header`). Please consolidate existing markup to use only the partial:
-
+* `form_buttons` has been deprecated. Any admin still using this partial should remove `fae/shared/form_buttons` and only use [fae/shared/form_header](docs/helpers/partials.md#form-header). `form_header` still supports `save_button_text`, `cancel_button_text`, `cloneable`, and `cloneable_text` options.
+* The `dark_hint` input option has been deprecated. The dark hint style was removed in v1.3, but now [the option](docs/helpers/form_helpers.md#global-options) has been removed. Please convert all `dark_hint` calls to `hint`.
+* The `form_header` partial includes the errors previously rendered as a separate partial as well as the parent node markup (`header.content-header.js-content-header`). Please consolidate existing markup to use only the partial:
 ```slim
 header.content-header.js-content-header
   = render 'fae/shared/form_header', header: @klass_name, f: f, item: @item
@@ -24,10 +21,9 @@ header.content-header.js-content-header
 
 = render 'fae/shared/form_header', header: @klass_name, f: f, item: @item
 ```
-
-`attr_toggle` has been deprecated. Use `fae_toggle` in it's place.
-
-Many CSS classes produced by v1.2 generators have been removed. It's easiest to re-scaffold your admin views entirely (chiefly `index.html.slim` and `_form.html.slim`, but also affecting `edit.html.slim` and `new.html.slim`). This CSS refactor also affects JavaScript; some features may break for admins that do not adopt the new CSS classes. Admins generated at or after v1.3 are unaffected.
+* `attr_toggle` has been deprecated. Use `fae_toggle` in its place.
+* Many CSS classes produced by v1.2 generators have been removed. It's easiest to re-scaffold your admin views entirely (chiefly `index.html.slim` and `_form.html.slim`, but also affecting `edit.html.slim` and `new.html.slim`). This CSS refactor also affects JavaScript; some features may break for admins that do not adopt the new CSS classes. Admins generated at or after v1.3 are unaffected.
+* `translate` has been renamed to `fae_translate`. Please refer to [the language documentation](docs/features/multi-language.md).
 
 # To v1.5
 

--- a/spec/dummy/app/models/wine.rb
+++ b/spec/dummy/app/models/wine.rb
@@ -16,7 +16,7 @@ class Wine < ActiveRecord::Base
 
   validates :name_en, :name_zh, :name_ja, presence: true
 
-  translate :name
+  fae_translate :name
 
   def fae_display_field
     name_en

--- a/spec/models/fae/base_spec.rb
+++ b/spec/models/fae/base_spec.rb
@@ -52,7 +52,7 @@ describe Fae::BaseModelConcern do
     end
   end
 
-  describe '#translate' do
+  describe '#fae_translate' do
     it 'should translate specified attributes' do
       wine = FactoryGirl.build_stubbed(:wine)
 


### PR DESCRIPTION
Avoids other gems injecting a `translate` method.