### PR TITLE
Clarifying supported Rails versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Like many Rails CMS engines, Fae delivers all the basics to get you up and running quickly: authentication, authorization, a sleek UI, form helpers, image processing and workflows. But unlike other engines, Fae's generated models, controllers, and views are built to customize and scale.
 
-Fae supports Rails 4.1 to 5.0. We are currently working on Rails 5.1 support.
+Fae 2.0 supports Rails 5.0 to 5.2, support for Rails 4.x is deprecated as of Fae 2.0.
 
 ## Installation
 


### PR DESCRIPTION
It appears you already support Rails 5.2 in the latest version of Fae, at least that's what is referenced int he Upgrading documentation.