### PR TITLE
left colour picker offset when sidenav present

### DIFF
--- a/app/assets/javascripts/fae/form/inputs/_color.js
+++ b/app/assets/javascripts/fae/form/inputs/_color.js
@@ -23,8 +23,9 @@ Fae.form.color = {
         var inputOffset = $elm.offset().top;
         var distanceToBottom = $(document).height() - inputOffset;
         var top = distanceToBottom <= this.$UI._height ? 414 : inputOffset + $elm.innerHeight();
+        var left = $elm.offset().left;
 
-        return { left: 30, top: top }
+        return { left: left, top: top }
       },
       renderCallback: function($elm, toggled) {
         var colors = this.color.colors;


### PR DESCRIPTION
When sidenav is present, the colour picker breaks. Picker's ```left``` CSS value is a static ```30px```, which puts it out of position relative to the form. Changed this to dynamic value.