### PR TITLE
Minor docs fix

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -94,4 +94,4 @@ heroku run rake db:migrate
 
 **Assets**
 
-Heroku [does not store assets](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem). Although this is not officially supported by Fae, it is possible to [https://github.com/wearefine/fae/issues/324#issuecomment-334578748](store assets uploaded to Fae with S3).
+Heroku [does not store assets](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem). Although this is not officially supported by Fae, it is possible to [store assets uploaded to Fae with S3](https://github.com/wearefine/fae/issues/324#issuecomment-334578748).


### PR DESCRIPTION
Syntax for Markdown links was incorrectly inverted and causing breakage on https://www.faecms.com/documentation/installation-index