### PR TITLE
only define StaticPage validations on Fae::TextField and Fae::TextArea

### DIFF
--- a/app/models/fae/static_page.rb
+++ b/app/models/fae/static_page.rb
@@ -42,8 +42,7 @@ module Fae
           languages.each do |lang|
             # Save with suffix for form fields
             define_association("#{name}_#{lang}", type)
-            # validations are only supported with Fae::TextField and Fae::TextArea
-            define_validations("#{name}_#{lang}", type, value[:validates]) if poly_sym(type) == :contentable && value.try(:[], :validates).present?
+            define_validations("#{name}_#{lang}", type, value[:validates]) if supports_validation(type, value)
           end
           # Save with lookup to have default language return in front-end use (don't need to worry about validations here)
           default_language = Rails.application.config.i18n.default_locale || languages.first
@@ -51,8 +50,7 @@ module Fae
         else
           # Normal content_blocks
           define_association(name, type)
-          # validations are only supported with Fae::TextField and Fae::TextArea
-          define_validations(name, type, value[:validates]) if poly_sym(type) == :contentable && value.try(:[], :validates).present?
+          define_validations(name, type, value[:validates]) if supports_validation(type, value)
         end
       end
 
@@ -75,6 +73,11 @@ module Fae
       type.send(:define_method, unique_method_name) do
         contentable.slug == slug && attached_as == name.to_s if contentable.present?
       end
+    end
+
+    def self.supports_validation(type, value)
+      # validations are only supported on Fae::TextField and Fae::TextArea
+      poly_sym(type) == :contentable && value.try(:[], :validates).present? 
     end
 
     def self.poly_sym(assoc)

--- a/app/models/fae/static_page.rb
+++ b/app/models/fae/static_page.rb
@@ -77,7 +77,7 @@ module Fae
 
     def self.supports_validation(type, value)
       # validations are only supported on Fae::TextField and Fae::TextArea
-      poly_sym(type) == :contentable && value.try(:[], :validates).present? 
+      poly_sym(type) == :contentable && value.try(:[], :validates).present?
     end
 
     def self.poly_sym(assoc)

--- a/app/models/fae/static_page.rb
+++ b/app/models/fae/static_page.rb
@@ -42,7 +42,8 @@ module Fae
           languages.each do |lang|
             # Save with suffix for form fields
             define_association("#{name}_#{lang}", type)
-            define_validations("#{name}_#{lang}", type, value[:validates]) if value.try(:[], :validates).present?
+            # validations are only supported with Fae::TextField and Fae::TextArea
+            define_validations("#{name}_#{lang}", type, value[:validates]) if poly_sym(type) == :contentable && value.try(:[], :validates).present?
           end
           # Save with lookup to have default language return in front-end use (don't need to worry about validations here)
           default_language = Rails.application.config.i18n.default_locale || languages.first
@@ -50,7 +51,8 @@ module Fae
         else
           # Normal content_blocks
           define_association(name, type)
-          define_validations(name, type, value[:validates]) if value.try(:[], :validates).present?
+          # validations are only supported with Fae::TextField and Fae::TextArea
+          define_validations(name, type, value[:validates]) if poly_sym(type) == :contentable && value.try(:[], :validates).present?
         end
       end
 

--- a/spec/models/fae/static_page_spec.rb
+++ b/spec/models/fae/static_page_spec.rb
@@ -100,4 +100,28 @@ describe Fae::StaticPage do
     end
   end
 
+  describe '.supports_validation' do
+    
+    context 'when the type is supported' do
+      it 'should return false without validates hash' do
+        expect(Fae::StaticPage.supports_validation(Fae::TextField, Fae::TextField)).to eq(false)
+        expect(Fae::StaticPage.supports_validation(Fae::TextField, { type: Fae::TextField })).to eq(false)
+      end
+
+      it 'should return true with validates hash' do
+        value = { type: Fae::TextField, validates: { presence: true } }
+        expect(Fae::StaticPage.supports_validation(Fae::TextField, value)).to eq(true)
+      end
+    end
+
+    context 'when the type is not supported' do
+      it 'should always return false' do
+        without_validates = { type: Fae::File }
+        with_validates = { type: Fae::Image, validates: { presence: true } }
+        expect(Fae::StaticPage.supports_validation(Fae::File, without_validates)).to eq(false)
+        expect(Fae::StaticPage.supports_validation(Fae::Image, with_validates)).to eq(false)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
If you define validations on a `Fae::Image` within `StaticPage#fae_fields` Fae will attach a method on `Fae::Image` that will raise an exception. This prevents the method from getting attached to unsupported models.