### PR TITLE
Nested AJAX form validation failure fix

### DIFF
--- a/app/assets/javascripts/fae/form/_ajax.js
+++ b/app/assets/javascripts/fae/form/_ajax.js
@@ -67,7 +67,7 @@ Fae.form.ajax = {
       }
 
       // Bind validation to nested form fields added by AJAX
-      Fae.form.validator.bindValidationEvents($scope = $('.nested-form'));
+      Fae.form.validator.bindValidationEvents($('.nested-form'));
 
       // Reinitialize form elements
       Fae.form.dates.initDatepicker();

--- a/app/assets/javascripts/fae/form/_ajax.js
+++ b/app/assets/javascripts/fae/form/_ajax.js
@@ -66,8 +66,8 @@ Fae.form.ajax = {
         $wrapper.find('.input.file').fileinputer();
       }
 
-      // Re-bind form validations to catch new AJAX loaded fields
-      Fae.form.validator.bindValidationEvents();
+      // Bind validation to nested form fields added by AJAX
+      Fae.form.validator.bindValidationEvents($scope = $('.nested-form'));
 
       // Reinitialize form elements
       Fae.form.dates.initDatepicker();

--- a/app/assets/javascripts/fae/form/_ajax.js
+++ b/app/assets/javascripts/fae/form/_ajax.js
@@ -66,6 +66,9 @@ Fae.form.ajax = {
         $wrapper.find('.input.file').fileinputer();
       }
 
+      // Re-bind form validations to catch new AJAX loaded fields
+      Fae.form.validator.bindValidationEvents();
+
       // Reinitialize form elements
       Fae.form.dates.initDatepicker();
       Fae.form.dates.initDateRangePicker();

--- a/app/assets/javascripts/fae/form/_validator.js
+++ b/app/assets/javascripts/fae/form/_validator.js
@@ -108,8 +108,12 @@ Fae.form.validator = {
   /**
    * Bind validation events based on input type
    */
-  bindValidationEvents: function ($scope = $('body')) {
+  bindValidationEvents: function ($scope) {
     var _this = this;
+
+    if (typeof($scope) === 'undefined'){
+      $scope = $('body');
+    }
 
     $scope.find('[data-validate]').each(function () {
       var $this = $(this);

--- a/app/assets/javascripts/fae/form/_validator.js
+++ b/app/assets/javascripts/fae/form/_validator.js
@@ -108,10 +108,10 @@ Fae.form.validator = {
   /**
    * Bind validation events based on input type
    */
-  bindValidationEvents: function () {
+  bindValidationEvents: function ($scope = $('body')) {
     var _this = this;
 
-    $('[data-validate]').each(function () {
+    $scope.find('[data-validate]').each(function () {
       var $this = $(this);
 
       if ($this.data('validate').length) {


### PR DESCRIPTION
## Summary ##
Adds a call to re-bind form field validation events after a nested AJAX form is loaded.

## Background ##
The way that _validator.js is set up runs through a loaded page and binds all the form fields that have `.data-validate` on them. But a nested form that is loaded via AJAX does not get addressed, so this change re-runs the binding action on the form after the new form fields are loaded.

Related issues:

- Redmine 75403
- Flow 35293743