### PR TITLE
Nested ajax form fixes for file attachment fields

### DIFF
--- a/app/assets/javascripts/fae/form/_ajax.js
+++ b/app/assets/javascripts/fae/form/_ajax.js
@@ -17,7 +17,6 @@ Fae.form.ajax = {
     this.addCancelLinks();
 
     this.imageDeleteLinks();
-    this.fileDeleteLinks();
     this.htmlListeners();
 
     this.deleteNoForm();
@@ -289,25 +288,22 @@ Fae.form.ajax = {
     });
   },
 
-  fileDeleteLinks: function() {
-    $('body' ).on('click', 'a.js-file-clear', (function(e) {
-
-      e.preventDefault();
-      var $this = $(this);
-
-      if (confirm('Are you sure you want to clear this file?')) {
-        $this.parent().next().show();
-        $this.parent().hide();
-      }
-    }));
-  },
-
   /**
    * Attaching click handlers to #js-main-content to allow ajax replacement
    * @todo Clean this up, moving listeners into their respective component classes (select, checkbox, etc.)
    */
   htmlListeners: function() {
     $('#js-main-content, .login-form > form')
+
+      /**
+       * For the delete button on file input
+       */
+      .on('click', '.js-file-clear', function(e) {
+        e.preventDefault();
+        var $parent = $(this).parent();
+        $parent.next().show();
+        $parent.hide();
+      })
 
       /**
        * For the yes/no slider

--- a/app/assets/javascripts/fae/form/_ajax.js
+++ b/app/assets/javascripts/fae/form/_ajax.js
@@ -17,6 +17,7 @@ Fae.form.ajax = {
     this.addCancelLinks();
 
     this.imageDeleteLinks();
+    this.fileDeleteLinks();
     this.htmlListeners();
 
     this.deleteNoForm();
@@ -286,6 +287,19 @@ Fae.form.ajax = {
         $this.parent().hide();
       }
     });
+  },
+
+  fileDeleteLinks: function() {
+    $('body' ).on('click', 'a.js-file-clear', (function(e) {
+
+      e.preventDefault();
+      var $this = $(this);
+
+      if (confirm('Are you sure you want to clear this file?')) {
+        $this.parent().next().show();
+        $this.parent().hide();
+      }
+    }));
   },
 
   /**

--- a/app/assets/javascripts/fae/form/_ajax.js
+++ b/app/assets/javascripts/fae/form/_ajax.js
@@ -10,6 +10,7 @@ Fae.form.ajax = {
   init: function() {
     this.$addedit_form = $('.js-addedit-form, .js-index-addedit-form');
     this.$filter_form = $('.js-filter-form');
+    this.$nested_form = $('.nested-form');
 
     this.addEditLinks();
     this.addEditSubmission();
@@ -67,7 +68,7 @@ Fae.form.ajax = {
       }
 
       // Bind validation to nested form fields added by AJAX
-      Fae.form.validator.bindValidationEvents($('.nested-form'));
+      Fae.form.validator.bindValidationEvents(this.$nested_form);
 
       // Reinitialize form elements
       Fae.form.dates.initDatepicker();
@@ -79,7 +80,7 @@ Fae.form.ajax = {
       Fae.form.checkbox.setCheckboxAsActive();
 
       // validate nested form fields on submit
-      Fae.form.validator.formValidate($('.nested-form'));
+      Fae.form.validator.formValidate(this.$nested_form);
 
       $wrapper.find('.hint').hinter();
     });

--- a/app/assets/javascripts/fae/form/_ajax.js
+++ b/app/assets/javascripts/fae/form/_ajax.js
@@ -78,6 +78,9 @@ Fae.form.ajax = {
       Fae.form.text.initMarkdown();
       Fae.form.checkbox.setCheckboxAsActive();
 
+      // validate nested form fields on submit
+      Fae.form.validator.formValidate($('.nested-form'));
+
       $wrapper.find('.hint').hinter();
     });
   },
@@ -129,7 +132,7 @@ Fae.form.ajax = {
           } else if ($html.hasClass('nested-form')) {
 
             // we're returning the form due to an error, just replace the form
-            $this.find( '.nested-form' ).replaceWith(data);
+            $this.find('.nested-form' ).replaceWith($html);
             $this.find('.select select').fae_chosen();
             $this.find('.input.file').fileinputer();
 

--- a/app/assets/javascripts/fae/form/_cancel.js
+++ b/app/assets/javascripts/fae/form/_cancel.js
@@ -35,4 +35,5 @@ Fae.form.cancel = {
 
     $('form').on('change', 'input, textarea, select', updateCancel);
   }
+
 };

--- a/app/assets/javascripts/fae/form/_validator.js
+++ b/app/assets/javascripts/fae/form/_validator.js
@@ -32,8 +32,7 @@ Fae.form.validator = {
     if (typeof($scope) === 'undefined'){
       $scope = FCH.$document;
     }
-
-    $scope.on('submit', function (e) {
+    $scope.on('submit', 'form:not([data-remote=true])', function (e) {
       var $this = $(this);
 
       if ($this.data('passed_validation') !== 'true') {

--- a/app/assets/javascripts/fae/form/_validator.js
+++ b/app/assets/javascripts/fae/form/_validator.js
@@ -26,10 +26,14 @@ Fae.form.validator = {
   /**
    * Validate the entire form on submit and stop it if the form is invalid
    */
-  formValidate: function () {
+  formValidate: function ($scope) {
     var _this = this;
 
-    FCH.$document.on('submit', 'form:not([data-remote=true])', function (e) {
+    if (typeof($scope) === 'undefined'){
+      $scope = FCH.$document;
+    }
+
+    $scope.on('submit', function (e) {
       var $this = $(this);
 
       if ($this.data('passed_validation') !== 'true') {
@@ -58,7 +62,7 @@ Fae.form.validator = {
           }
         });
 
-        _this.testValidation($this);
+        _this.testValidation($this, $scope);
 
       }
 
@@ -69,7 +73,7 @@ Fae.form.validator = {
    * Tests a forms validation after all validation checks have responded
    * Polls validations responses every 50ms to allow uniqueness AJAX calls to complete
    */
-  testValidation: function($this) {
+  testValidation: function($this, $scope) {
     var _this = this;
     _this.validation_test_count++;
 
@@ -84,9 +88,11 @@ Fae.form.validator = {
 
           $this.submit();
         } else {
-          // otherwise scroll to the top to display alerts
+          // otherwise scroll to the top to display alerts (unless in a nested form scope)
           Fae.navigation.language.checkForHiddenErrors();
-          FCH.smoothScroll($('#js-main-header'), 500, 100, 0);
+          if (typeof($scope) === 'undefined') {
+            FCH.smoothScroll($('#js-main-header'), 500, 100, 0);
+          }
 
           if ($(".field_with_errors").length) {
             $('.alert').slideDown('fast').delay(3000).slideUp('fast');

--- a/app/views/fae/application/_file_uploader.html.slim
+++ b/app/views/fae/application/_file_uploader.html.slim
@@ -28,7 +28,10 @@ ruby:
         .asset-actions.-files
           a.asset-title href=the_file.asset.url target="_blank" = the_file.asset.file.filename
 
-          = link_to '', fae.delete_file_path(the_file.id), class: 'asset-delete js-asset-delete', remote: true, method: :delete, data: { confirm: t('fae.delete_confirmation') }
+          - if the_file.id.present?
+            = link_to '', fae.delete_file_path(the_file.id), class: 'asset-delete js-asset-delete', remote: true, method: :delete, data: { confirm: t('fae.delete_confirmation') }
+          - else
+            = link_to '', fae.delete_file_path, class: 'asset-delete js-asset-delete', remote: true, method: :delete
 
       .asset-inputs style="#{'display: none;' unless the_file.asset.blank?}"
         = i.input :asset, as: :file, label: false, input_html: { data: { limit: Fae.max_file_upload_size, exceeded: t('fae.exceeded_upload_limit') } }

--- a/app/views/fae/application/_file_uploader.html.slim
+++ b/app/views/fae/application/_file_uploader.html.slim
@@ -31,7 +31,7 @@ ruby:
           - if the_file.id.present?
             = link_to '', fae.delete_file_path(the_file.id), class: 'asset-delete js-asset-delete', remote: true, method: :delete, data: { confirm: t('fae.delete_confirmation') }
           - else
-            = link_to '', fae.delete_file_path, class: 'asset-delete js-asset-delete', remote: true, method: :delete
+            a.js-file-clear.asset-delete.js-asset-delete
 
       .asset-inputs style="#{'display: none;' unless the_file.asset.blank?}"
         = i.input :asset, as: :file, label: false, input_html: { data: { limit: Fae.max_file_upload_size, exceeded: t('fae.exceeded_upload_limit') } }


### PR DESCRIPTION
Nested form validations are not triggering in cases where a form field is not touched by a blur event.  A user can fill click submit on an empty or partially empty set of nested forms and no form validations will be triggered. This fixes by passing the nested-form as a scope so that a submit click listener can be initialized on the nested form.

I also made some changes to fix a minor bug with the delete link on the file input in cases where the object was not saved successfully. If there are form errors, there is no `file.id` so the delete file path would break the form during rendering. I added an alternate simple <a> tag link with some JS to handle clearing the file input in this circumstance.

This work is related to Redmine issue 75403