### PR TITLE
Issue #409 - fix bugs in stripValidation()

### DIFF
--- a/app/assets/javascripts/fae/form/_validator.js
+++ b/app/assets/javascripts/fae/form/_validator.js
@@ -268,12 +268,13 @@ Fae.form.validator = {
       // if the kind matches, remove it from the array
       if (validations[i]['kind'] === kind) {
         validations.splice(i, 1);
+        i--;
+      } else {
+        // otherwise convert JSON back to a string
+        validations[i] = JSON.stringify(validations[i]);
       }
-
-      // convert JSON back to a string
-      validations[i] = JSON.stringify(validations[i]);
     }
-    $field.attr('data-validate', '[' + validations + ']');
+    $field.data('validate', '[' + validations + ']');
   },
 
   /**


### PR DESCRIPTION
Fixes issue #409 

In my case this issue manifested in being able to update users only in Firefox, but not Chrome or Edge.

Two bugs were fixed:

- Deleting an item from the array "skips over" the next item because the array gets shortened
- jQuery.attr leads to double-stringifying of objects which Judge chokes on (but apparently not in Firefox)
