### PR TITLE
Fixes #432 - Create association on locale change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'sass', require: 'sass'
 group :test, :development do
   gem 'rspec-rails', '~> 3.6.0'
   gem 'pry'
+  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       debug_inspector (>= 0.0.1)
     browser (2.5.3)
     builder (3.2.3)
+    byebug (10.0.2)
     capistrano (3.10.1)
       airbrussh (>= 1.0.0)
       i18n
@@ -226,6 +227,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     public_suffix (3.0.2)
     rack (2.0.4)
     rack-test (1.0.0)
@@ -368,6 +372,7 @@ DEPENDENCIES
   guard-rspec (~> 4.7.3)
   mysql2
   pry
+  pry-byebug
   rails (~> 5.2.0)
   rails-controller-testing
   rails-perftest
@@ -381,4 +386,4 @@ DEPENDENCIES
   yarjuf
 
 BUNDLED WITH
-   1.13.0
+   1.16.5

--- a/app/models/fae/static_page.rb
+++ b/app/models/fae/static_page.rb
@@ -1,15 +1,14 @@
 module Fae
   class StaticPage < ActiveRecord::Base
-
     include Fae::BaseModelConcern
     include Fae::StaticPageConcern
 
     validates :title, presence: true
 
-    @singleton_is_setup = false
+    @current_locale = I18n.locale
 
     def self.instance
-      setup_dynamic_singleton
+      setup_dynamic_methods
       row = includes(fae_fields.keys).references(fae_fields.keys).find_by_slug(@slug)
       row = create(title: @slug.titleize, slug: @slug) if row.blank?
       row
@@ -31,35 +30,47 @@ module Fae
 
   private
 
-    def self.setup_dynamic_singleton
-      return if @singleton_is_setup
-
+    def self.setup_dynamic_methods
       fae_fields.each do |name, value|
         type = value.is_a?(Hash) ? value[:type] : value
-        languages = value.try(:[], :languages)
+        languages = value.try(:[], :languages) || []
+        process_field(languages, name, type, value)
+      end
+      @current_locale = I18n.locale
+    end
 
-        if languages.present?
-          languages.each do |lang|
-            # Save with suffix for form fields
-            define_association("#{name}_#{lang}", type)
-            define_validations("#{name}_#{lang}", type, value[:validates]) if supports_validation(type, value)
-          end
-          # Save with lookup to have default language return in front-end use (don't need to worry about validations here)
-          default_language = Rails.application.config.i18n.default_locale || languages.first
-          define_association(name, type, "#{name}_#{default_language}")
-        else
-          # Normal content_blocks
-          define_association(name, type)
-          define_validations(name, type, value[:validates]) if supports_validation(type, value)
+    def self.process_field(languages, name, type, value)
+      return methods_without_lang(name, type, value) if languages.empty?
+      process_field_with_lang languages, name, type, value
+    end
+
+    def self.process_field_with_lang(languages, name, type, value)
+      methods_with_lang(languages, name, type, value)
+
+      if I18n.locale != @current_locale
+        define_association(name, type, "#{name}_#{I18n.locale}")
+      end
+    end
+
+    def self.methods_with_lang(languages, name, type, value)
+      languages.each do |lang|
+        # Save with suffix for form fields
+        define_association("#{name}_#{lang}", type)
+        if supports_validation(type, value)
+          define_validations("#{name}_#{lang}", type, value[:validates])
         end
       end
+    end
 
-      @singleton_is_setup = true
+    def self.methods_without_lang(name, type, value)
+      define_association(name, type)
+      if supports_validation(type, value)
+        define_validations(name, type, value[:validates])
+      end
     end
 
     def self.define_association(name, type, locale_name = nil)
       locale_name ||= name
-
       send :has_one, name.to_sym, -> { where(attached_as: locale_name.to_s)}, as: poly_sym(type), class_name: type.to_s, dependent: :destroy
       send :accepts_nested_attributes_for, name, allow_destroy: true
       send :define_method, :"#{name}_content", -> { send(name.to_sym).try(:content) }
@@ -67,7 +78,13 @@ module Fae
 
     def self.define_validations(name, type, validations)
       unique_method_name = "is_#{self.name.underscore}_#{name.to_s}?".to_sym
-      slug = @slug
+      return if type.validators.any? do |val|
+        val.options[:if] == unique_method_name
+      end
+      add_validations unique_method_name, type, validations, @slug
+    end
+
+    def self.add_validations(unique_method_name, type, validations, slug)
       validations[:if] = unique_method_name
       type.validates(:content, validations)
       type.send(:define_method, unique_method_name) do
@@ -104,6 +121,5 @@ module Fae
         return assoc_obj.as_json
       end
     end
-
   end
 end


### PR DESCRIPTION
According to the docs, calling MyPage.instance.header
should get the header text for current locale.
However, the associations are set up in a singleton
for a default locale and never modified.

The language-specific methods like MyPage.instance.header_en
still work, but it would be nice to have fae handle the locale
for us.

This change checks for languages in fae_fields for page
and dynamically changes the association if the locale change
is detected.