### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/quickstart-guide.md
+++ b/docs/quickstart-guide.md
@@ -137,7 +137,7 @@ validates :title, presence: true
 validates :slug, Fae.validation_helpers.slug
 ```
 
-Fae uses [Judge](https://github.com/joecorcoran/judge) for client side validations. Judge requires you to expose any attributes that have a uniqueness validation. You can do this in `config/initializers/jugde.rb`:
+Fae uses [Judge](https://github.com/joecorcoran/judge) for client side validations. Judge requires you to expose any attributes that have a uniqueness validation. You can do this in `config/initializers/judge.rb`:
 
 ```ruby
 Judge.configure do

--- a/docs/topics/models.md
+++ b/docs/topics/models.md
@@ -141,7 +141,7 @@ validates :slug, Fae.validation_helpers.slug
 
 ### Judge and Uniqueness
 
-Fae uses [Judge](https://github.com/joecorcoran/judge) to automatically add client side validation from the declarations in the models. The caveat is Judge requires you to expose any attributes that have a uniqueness validation. You can do this in `config/initializers/jugde.rb`:
+Fae uses [Judge](https://github.com/joecorcoran/judge) to automatically add client side validation from the declarations in the models. The caveat is Judge requires you to expose any attributes that have a uniqueness validation. You can do this in `config/initializers/judge.rb`:
 
 ```ruby
 Judge.configure do


### PR DESCRIPTION
Fix two typos in the documentation—the word "judge" was misspelled as "jugde."