### PR TITLE
adds Rails versions to dummy migrations

### DIFF
--- a/spec/dummy/db/migrate/20140827225157_create_releases.rb
+++ b/spec/dummy/db/migrate/20140827225157_create_releases.rb
@@ -1,4 +1,4 @@
-class CreateReleases < ActiveRecord::Migration
+class CreateReleases < ActiveRecord::Migration[4.2]
   def change
     create_table :releases do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20140902223650_create_wine.rb
+++ b/spec/dummy/db/migrate/20140902223650_create_wine.rb
@@ -1,4 +1,4 @@
-class CreateWine < ActiveRecord::Migration
+class CreateWine < ActiveRecord::Migration[4.2]
   def change
     create_table :wines do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20140902225712_create_varietal.rb
+++ b/spec/dummy/db/migrate/20140902225712_create_varietal.rb
@@ -1,4 +1,4 @@
-class CreateVarietal < ActiveRecord::Migration
+class CreateVarietal < ActiveRecord::Migration[4.2]
   def change
     create_table :varietals do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20140902230910_create_release_selling_point.rb
+++ b/spec/dummy/db/migrate/20140902230910_create_release_selling_point.rb
@@ -1,4 +1,4 @@
-class CreateReleaseSellingPoint < ActiveRecord::Migration
+class CreateReleaseSellingPoint < ActiveRecord::Migration[4.2]
   def change
     create_table :release_selling_points do |t|
       t.references :release

--- a/spec/dummy/db/migrate/20140902231710_create_selling_points.rb
+++ b/spec/dummy/db/migrate/20140902231710_create_selling_points.rb
@@ -1,4 +1,4 @@
-class CreateSellingPoints < ActiveRecord::Migration
+class CreateSellingPoints < ActiveRecord::Migration[4.2]
   def change
     create_table :selling_points do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20140902233505_create_acclaim.rb
+++ b/spec/dummy/db/migrate/20140902233505_create_acclaim.rb
@@ -1,4 +1,4 @@
-class CreateAcclaim < ActiveRecord::Migration
+class CreateAcclaim < ActiveRecord::Migration[4.2]
   def change
     create_table :acclaims do |t|
       t.string :score

--- a/spec/dummy/db/migrate/20140905221522_create_events.rb
+++ b/spec/dummy/db/migrate/20140905221522_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration
+class CreateEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :events do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20140905221727_create_people.rb
+++ b/spec/dummy/db/migrate/20140905221727_create_people.rb
@@ -1,4 +1,4 @@
-class CreatePeople < ActiveRecord::Migration
+class CreatePeople < ActiveRecord::Migration[4.2]
   def change
     create_table :people do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20140905223641_create_event_release.rb
+++ b/spec/dummy/db/migrate/20140905223641_create_event_release.rb
@@ -1,4 +1,4 @@
-class CreateEventRelease < ActiveRecord::Migration
+class CreateEventRelease < ActiveRecord::Migration[4.2]
   def change
     create_table :event_releases do |t|
       t.references :release, index: true

--- a/spec/dummy/db/migrate/20140905231309_rename_column_in_events_table.rb
+++ b/spec/dummy/db/migrate/20140905231309_rename_column_in_events_table.rb
@@ -1,4 +1,4 @@
-class RenameColumnInEventsTable < ActiveRecord::Migration
+class RenameColumnInEventsTable < ActiveRecord::Migration[4.2]
   def change
     rename_column :events, :people_id, :person_id
   end

--- a/spec/dummy/db/migrate/20140905232047_add_event_id_to_people.rb
+++ b/spec/dummy/db/migrate/20140905232047_add_event_id_to_people.rb
@@ -1,4 +1,4 @@
-class AddEventIdToPeople < ActiveRecord::Migration
+class AddEventIdToPeople < ActiveRecord::Migration[4.2]
   def change
     add_column :people, :event_id, :integer
   end

--- a/spec/dummy/db/migrate/20141006185920_add_video_to_release.rb
+++ b/spec/dummy/db/migrate/20141006185920_add_video_to_release.rb
@@ -1,4 +1,4 @@
-class AddVideoToRelease < ActiveRecord::Migration
+class AddVideoToRelease < ActiveRecord::Migration[4.2]
   def change
     add_column :releases, :video_url, :string
   end

--- a/spec/dummy/db/migrate/20141009155137_add_on_env_to_people.rb
+++ b/spec/dummy/db/migrate/20141009155137_add_on_env_to_people.rb
@@ -1,4 +1,4 @@
-class AddOnEnvToPeople < ActiveRecord::Migration
+class AddOnEnvToPeople < ActiveRecord::Migration[4.2]
   def change
     add_column :people, :on_stage, :boolean, default: true
     add_column :people, :on_prod, :boolean, default: false

--- a/spec/dummy/db/migrate/20141009200746_add_position_to_people.rb
+++ b/spec/dummy/db/migrate/20141009200746_add_position_to_people.rb
@@ -1,4 +1,4 @@
-class AddPositionToPeople < ActiveRecord::Migration
+class AddPositionToPeople < ActiveRecord::Migration[4.2]
   def change
     add_column :people, :position, :integer
   end

--- a/spec/dummy/db/migrate/20141017200415_add_user_table.fae.rb
+++ b/spec/dummy/db/migrate/20141017200415_add_user_table.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20140809222030)
-class AddUserTable < ActiveRecord::Migration
+class AddUserTable < ActiveRecord::Migration[4.2]
   def change
     create_table(:fae_users) do |t|
       ## Database authenticatable

--- a/spec/dummy/db/migrate/20141019043830_create_fae_roles.fae.rb
+++ b/spec/dummy/db/migrate/20141019043830_create_fae_roles.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20140822224029)
-class CreateFaeRoles < ActiveRecord::Migration
+class CreateFaeRoles < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_roles do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20141019043831_create_fae_images_table.fae.rb
+++ b/spec/dummy/db/migrate/20141019043831_create_fae_images_table.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141008180718)
-class CreateFaeImagesTable < ActiveRecord::Migration
+class CreateFaeImagesTable < ActiveRecord::Migration[4.2]
   def change
     create_table(:fae_images) do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20141019043832_add_file_size_to_fae_images.fae.rb
+++ b/spec/dummy/db/migrate/20141019043832_add_file_size_to_fae_images.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141013212642)
-class AddFileSizeToFaeImages < ActiveRecord::Migration
+class AddFileSizeToFaeImages < ActiveRecord::Migration[4.2]
   def change
     add_column :fae_images, :file_size, :integer
   end

--- a/spec/dummy/db/migrate/20141019043833_create_fae_options.fae.rb
+++ b/spec/dummy/db/migrate/20141019043833_create_fae_options.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141017194616)
-class CreateFaeOptions < ActiveRecord::Migration
+class CreateFaeOptions < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_options do |t|
       t.string :title

--- a/spec/dummy/db/migrate/20141021161543_remove_faviconable_from_fae_image.fae.rb
+++ b/spec/dummy/db/migrate/20141021161543_remove_faviconable_from_fae_image.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141021161414)
-class RemoveFaviconableFromFaeImage < ActiveRecord::Migration
+class RemoveFaviconableFromFaeImage < ActiveRecord::Migration[4.2]
   def change
     remove_reference :fae_images, :faviconable, polymorphic: true, index: true
   end

--- a/spec/dummy/db/migrate/20141021181927_create_fae_files.fae.rb
+++ b/spec/dummy/db/migrate/20141021181927_create_fae_files.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141021181327)
-class CreateFaeFiles < ActiveRecord::Migration
+class CreateFaeFiles < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_files do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20141021183653_create_fae_text_areas.fae.rb
+++ b/spec/dummy/db/migrate/20141021183653_create_fae_text_areas.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141021183047)
-class CreateFaeTextAreas < ActiveRecord::Migration
+class CreateFaeTextAreas < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_text_areas do |t|
       t.integer :contentable, polymorphic: true, index: true

--- a/spec/dummy/db/migrate/20141021184641_create_fae_pages.fae.rb
+++ b/spec/dummy/db/migrate/20141021184641_create_fae_pages.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141021184311)
-class CreateFaePages < ActiveRecord::Migration
+class CreateFaePages < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_pages do |t|
       t.string :title

--- a/spec/dummy/db/migrate/20141027234702_add_publication_date_to_acclaim.rb
+++ b/spec/dummy/db/migrate/20141027234702_add_publication_date_to_acclaim.rb
@@ -1,4 +1,4 @@
-class AddPublicationDateToAcclaim < ActiveRecord::Migration
+class AddPublicationDateToAcclaim < ActiveRecord::Migration[4.2]
   def change
     add_column :acclaims, :publication_date, :date
   end

--- a/spec/dummy/db/migrate/20141105213344_change_fae_text_areas.fae.rb
+++ b/spec/dummy/db/migrate/20141105213344_change_fae_text_areas.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141105210119)
-class ChangeFaeTextAreas < ActiveRecord::Migration
+class ChangeFaeTextAreas < ActiveRecord::Migration[4.2]
   def change
     change_table :fae_text_areas do |t|
       t.remove :contentable

--- a/spec/dummy/db/migrate/20141105221151_create_fae_text_fields.fae.rb
+++ b/spec/dummy/db/migrate/20141105221151_create_fae_text_fields.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141105214814)
-class CreateFaeTextFields < ActiveRecord::Migration
+class CreateFaeTextFields < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_text_fields do |t|
       t.references :contentable, polymorphic: true, index: true

--- a/spec/dummy/db/migrate/20141106223652_create_locations.rb
+++ b/spec/dummy/db/migrate/20141106223652_create_locations.rb
@@ -1,4 +1,4 @@
-class CreateLocations < ActiveRecord::Migration
+class CreateLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :locations do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20141120052810_add_required_to_images_and_files.fae.rb
+++ b/spec/dummy/db/migrate/20141120052810_add_required_to_images_and_files.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141120051309)
-class AddRequiredToImagesAndFiles < ActiveRecord::Migration
+class AddRequiredToImagesAndFiles < ActiveRecord::Migration[4.2]
   def change
     add_column :fae_files, :required, :boolean, default: false
     add_column :fae_images, :required, :boolean, default: false

--- a/spec/dummy/db/migrate/20141123214713_change_fae_page_to_fae_static_page.fae.rb
+++ b/spec/dummy/db/migrate/20141123214713_change_fae_page_to_fae_static_page.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141123080842)
-class ChangeFaePageToFaeStaticPage < ActiveRecord::Migration
+class ChangeFaePageToFaeStaticPage < ActiveRecord::Migration[4.2]
   def change
     rename_table :fae_pages, :fae_static_pages
   end

--- a/spec/dummy/db/migrate/20141126180655_change_field_in_fae_text_fields.fae.rb
+++ b/spec/dummy/db/migrate/20141126180655_change_field_in_fae_text_fields.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20141126180534)
-class ChangeFieldInFaeTextFields < ActiveRecord::Migration
+class ChangeFieldInFaeTextFields < ActiveRecord::Migration[4.2]
   def change
     rename_column :fae_text_fields, :attatched_as, :attached_as
   end

--- a/spec/dummy/db/migrate/20141223225922_add_featured_to_releases.rb
+++ b/spec/dummy/db/migrate/20141223225922_add_featured_to_releases.rb
@@ -1,4 +1,4 @@
-class AddFeaturedToReleases < ActiveRecord::Migration
+class AddFeaturedToReleases < ActiveRecord::Migration[4.2]
   def change
     add_column :releases, :featured, :boolean
   end

--- a/spec/dummy/db/migrate/20150213170720_add_weight_to_releases.rb
+++ b/spec/dummy/db/migrate/20150213170720_add_weight_to_releases.rb
@@ -1,4 +1,4 @@
-class AddWeightToReleases < ActiveRecord::Migration
+class AddWeightToReleases < ActiveRecord::Migration[4.2]
   def change
     add_column :releases, :weight, :string
   end

--- a/spec/dummy/db/migrate/20150213172238_create_aromas.rb
+++ b/spec/dummy/db/migrate/20150213172238_create_aromas.rb
@@ -1,4 +1,4 @@
-class CreateAromas < ActiveRecord::Migration
+class CreateAromas < ActiveRecord::Migration[4.2]
   def change
     create_table :aromas do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20150213173312_add_release_id_to_aromas.rb
+++ b/spec/dummy/db/migrate/20150213173312_add_release_id_to_aromas.rb
@@ -1,4 +1,4 @@
-class AddReleaseIdToAromas < ActiveRecord::Migration
+class AddReleaseIdToAromas < ActiveRecord::Migration[4.2]
   def change
     add_reference :aromas, :release, index: true
   end

--- a/spec/dummy/db/migrate/20150213185222_add_date_fields_to_releases.rb
+++ b/spec/dummy/db/migrate/20150213185222_add_date_fields_to_releases.rb
@@ -1,4 +1,4 @@
-class AddDateFieldsToReleases < ActiveRecord::Migration
+class AddDateFieldsToReleases < ActiveRecord::Migration[4.2]
   def change
     add_column :releases, :release_date, :date
     add_column :releases, :show, :date

--- a/spec/dummy/db/migrate/20150305214314_create_teams.rb
+++ b/spec/dummy/db/migrate/20150305214314_create_teams.rb
@@ -1,4 +1,4 @@
-class CreateTeams < ActiveRecord::Migration
+class CreateTeams < ActiveRecord::Migration[4.2]
   def change
     create_table :teams do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20150305215553_create_players.rb
+++ b/spec/dummy/db/migrate/20150305215553_create_players.rb
@@ -1,4 +1,4 @@
-class CreatePlayers < ActiveRecord::Migration
+class CreatePlayers < ActiveRecord::Migration[4.2]
   def change
     create_table :players do |t|
       t.string :first_name

--- a/spec/dummy/db/migrate/20150305215901_create_coaches.rb
+++ b/spec/dummy/db/migrate/20150305215901_create_coaches.rb
@@ -1,4 +1,4 @@
-class CreateCoaches < ActiveRecord::Migration
+class CreateCoaches < ActiveRecord::Migration[4.2]
   def change
     create_table :coaches do |t|
       t.string :first_name

--- a/spec/dummy/db/migrate/20150508224216_add_languages_to_wines.rb
+++ b/spec/dummy/db/migrate/20150508224216_add_languages_to_wines.rb
@@ -1,4 +1,4 @@
-class AddLanguagesToWines < ActiveRecord::Migration
+class AddLanguagesToWines < ActiveRecord::Migration[4.2]
   def change
     rename_column :wines, :name, :name_en
     add_column :wines, :name_zh, :string

--- a/spec/dummy/db/migrate/20150513172042_add_language_to_users.fae.rb
+++ b/spec/dummy/db/migrate/20150513172042_add_language_to_users.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20150513170213)
-class AddLanguageToUsers < ActiveRecord::Migration
+class AddLanguageToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :fae_users, :language, :string
   end

--- a/spec/dummy/db/migrate/20150825231046_add_slug_to_aromas.rb
+++ b/spec/dummy/db/migrate/20150825231046_add_slug_to_aromas.rb
@@ -1,4 +1,4 @@
-class AddSlugToAromas < ActiveRecord::Migration
+class AddSlugToAromas < ActiveRecord::Migration[4.2]
   def change
     add_column :aromas, :slug, :string
   end

--- a/spec/dummy/db/migrate/20150909230658_create_cats.rb
+++ b/spec/dummy/db/migrate/20150909230658_create_cats.rb
@@ -1,4 +1,4 @@
-class CreateCats < ActiveRecord::Migration
+class CreateCats < ActiveRecord::Migration[4.2]
   def change
     create_table :cats do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20150925190110_create_validation_testers.rb
+++ b/spec/dummy/db/migrate/20150925190110_create_validation_testers.rb
@@ -1,4 +1,4 @@
-class CreateValidationTesters < ActiveRecord::Migration
+class CreateValidationTesters < ActiveRecord::Migration[4.2]
   def change
     create_table :validation_testers do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20150929195433_add_extra_fields_to_validation_testers.rb
+++ b/spec/dummy/db/migrate/20150929195433_add_extra_fields_to_validation_testers.rb
@@ -1,4 +1,4 @@
-class AddExtraFieldsToValidationTesters < ActiveRecord::Migration
+class AddExtraFieldsToValidationTesters < ActiveRecord::Migration[4.2]
   def change
     add_column :validation_testers, :second_email, :string
     add_column :validation_testers, :unique_email, :string

--- a/spec/dummy/db/migrate/20151001210315_create_fae_changes.fae.rb
+++ b/spec/dummy/db/migrate/20151001210315_create_fae_changes.fae.rb
@@ -1,5 +1,5 @@
 # This migration comes from fae (originally 20150930224821)
-class CreateFaeChanges < ActiveRecord::Migration
+class CreateFaeChanges < ActiveRecord::Migration[4.2]
   def change
     create_table :fae_changes do |t|
       t.integer :changeable_id

--- a/spec/dummy/db/migrate/20151013225140_create_winemakers.rb
+++ b/spec/dummy/db/migrate/20151013225140_create_winemakers.rb
@@ -1,4 +1,4 @@
-class CreateWinemakers < ActiveRecord::Migration
+class CreateWinemakers < ActiveRecord::Migration[4.2]
   def change
     create_table :winemakers do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20151125182540_add_description_to_releases.rb
+++ b/spec/dummy/db/migrate/20151125182540_add_description_to_releases.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToReleases < ActiveRecord::Migration
+class AddDescriptionToReleases < ActiveRecord::Migration[4.2]
   def change
     add_column :releases, :description, :text
   end

--- a/spec/dummy/db/migrate/20151219002458_add_position_to_events.rb
+++ b/spec/dummy/db/migrate/20151219002458_add_position_to_events.rb
@@ -1,4 +1,4 @@
-class AddPositionToEvents < ActiveRecord::Migration
+class AddPositionToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :position, :integer
   end

--- a/spec/dummy/db/migrate/20160116014913_create_to_be_destroyeds.rb
+++ b/spec/dummy/db/migrate/20160116014913_create_to_be_destroyeds.rb
@@ -1,4 +1,4 @@
-class CreateToBeDestroyeds < ActiveRecord::Migration
+class CreateToBeDestroyeds < ActiveRecord::Migration[4.2]
   def change
     create_table :to_be_destroyeds do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20160116015621_destroy_to_be_destroyed.rb
+++ b/spec/dummy/db/migrate/20160116015621_destroy_to_be_destroyed.rb
@@ -1,4 +1,4 @@
-class DestroyToBeDestroyed < ActiveRecord::Migration
+class DestroyToBeDestroyed < ActiveRecord::Migration[4.2]
   def change
     drop_table :to_be_destroyeds
   end

--- a/spec/dummy/db/migrate/20160226000222_remove_foreign_key_for_rails_4_1_support.rb
+++ b/spec/dummy/db/migrate/20160226000222_remove_foreign_key_for_rails_4_1_support.rb
@@ -1,4 +1,4 @@
-class RemoveForeignKeyForRails41Support < ActiveRecord::Migration
+class RemoveForeignKeyForRails41Support < ActiveRecord::Migration[4.2]
   def change
     remove_foreign_key :winemakers, :wines
   end

--- a/spec/dummy/db/migrate/20160311225043_add_aroma_id_to_cats.rb
+++ b/spec/dummy/db/migrate/20160311225043_add_aroma_id_to_cats.rb
@@ -1,4 +1,4 @@
-class AddAromaIdToCats < ActiveRecord::Migration
+class AddAromaIdToCats < ActiveRecord::Migration[4.2]
   def change
     add_column :cats, :aroma_id, :integer
   end

--- a/spec/dummy/db/migrate/20160413202106_create_milestones.rb
+++ b/spec/dummy/db/migrate/20160413202106_create_milestones.rb
@@ -1,4 +1,4 @@
-class CreateMilestones < ActiveRecord::Migration
+class CreateMilestones < ActiveRecord::Migration[4.2]
   def change
     create_table :milestones do |t|
       t.integer :year

--- a/spec/dummy/db/migrate/20160414221357_create_jerseys.rb
+++ b/spec/dummy/db/migrate/20160414221357_create_jerseys.rb
@@ -1,4 +1,4 @@
-class CreateJerseys < ActiveRecord::Migration
+class CreateJerseys < ActiveRecord::Migration[4.2]
   def change
     create_table :jerseys do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20160419164359_add_region_type_to_winemaker.rb
+++ b/spec/dummy/db/migrate/20160419164359_add_region_type_to_winemaker.rb
@@ -1,4 +1,4 @@
-class AddRegionTypeToWinemaker < ActiveRecord::Migration
+class AddRegionTypeToWinemaker < ActiveRecord::Migration[4.2]
   def change
     add_column :winemakers, :region_type, :integer
   end

--- a/spec/dummy/db/migrate/20160815162731_create_release_notes.rb
+++ b/spec/dummy/db/migrate/20160815162731_create_release_notes.rb
@@ -1,4 +1,4 @@
-class CreateReleaseNotes < ActiveRecord::Migration
+class CreateReleaseNotes < ActiveRecord::Migration[4.2]
   def change
     create_table :release_notes do |t|
       t.string :title

--- a/spec/dummy/db/migrate/20160815163139_add_release_id_to_release_notes.rb
+++ b/spec/dummy/db/migrate/20160815163139_add_release_id_to_release_notes.rb
@@ -1,4 +1,4 @@
-class AddReleaseIdToReleaseNotes < ActiveRecord::Migration
+class AddReleaseIdToReleaseNotes < ActiveRecord::Migration[4.2]
   def change
     add_reference :release_notes, :release, index: true
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,409 +10,410 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171121212302) do
+ActiveRecord::Schema.define(version: 2017_11_21_212302) do
 
-  create_table "acclaims", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "score"
-    t.string   "publication"
-    t.text     "description",      limit: 65535
-    t.boolean  "on_stage",                       default: true
-    t.boolean  "on_prod",                        default: false
-    t.integer  "position"
-    t.integer  "release_id"
+  create_table "acclaims", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "score"
+    t.string "publication"
+    t.text "description"
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
+    t.integer "position"
+    t.integer "release_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.date     "publication_date"
+    t.date "publication_date"
   end
 
-  create_table "aromas", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.text     "description", limit: 65535
-    t.integer  "position"
-    t.boolean  "live"
+  create_table "aromas", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.integer "position"
+    t.boolean "live"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "release_id"
-    t.string   "slug"
-    t.index ["release_id"], name: "index_aromas_on_release_id", using: :btree
+    t.integer "release_id"
+    t.string "slug"
+    t.index ["release_id"], name: "index_aromas_on_release_id"
   end
 
-  create_table "article_categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.integer  "position"
+  create_table "article_categories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "title"
-    t.text     "body",                limit: 65535
-    t.integer  "position"
-    t.integer  "article_category_id"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.index ["article_category_id"], name: "index_articles_on_article_category_id", using: :btree
+  create_table "articles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.integer "position"
+    t.integer "article_category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_category_id"], name: "index_articles_on_article_category_id"
   end
 
-  create_table "beers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.string   "seo_title"
-    t.string   "seo_description"
-    t.boolean  "on_stage"
-    t.boolean  "on_prod"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+  create_table "beers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "seo_title"
+    t.string "seo_description"
+    t.boolean "on_stage"
+    t.boolean "on_prod"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "cats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.boolean  "friendly"
-    t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
-    t.integer  "aroma_id"
+  create_table "cats", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.boolean "friendly"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "aroma_id"
   end
 
-  create_table "coaches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "role"
-    t.text     "bio",        limit: 65535
-    t.integer  "team_id"
+  create_table "coaches", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "role"
+    t.text "bio"
+    t.integer "team_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["team_id"], name: "index_coaches_on_team_id", using: :btree
+    t.index ["team_id"], name: "index_coaches_on_team_id"
   end
 
-  create_table "event_releases", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "release_id"
-    t.integer  "event_id"
+  create_table "event_releases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "release_id"
+    t.integer "event_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["event_id"], name: "index_event_releases_on_event_id", using: :btree
-    t.index ["release_id"], name: "index_event_releases_on_release_id", using: :btree
+    t.index ["event_id"], name: "index_event_releases_on_event_id"
+    t.index ["release_id"], name: "index_event_releases_on_release_id"
   end
 
-  create_table "events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.date     "start_date"
-    t.date     "end_date"
-    t.string   "event_type"
-    t.string   "city"
-    t.integer  "person_id"
+  create_table "events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.date "start_date"
+    t.date "end_date"
+    t.string "event_type"
+    t.string "city"
+    t.integer "person_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "position"
+    t.integer "position"
   end
 
-  create_table "fae_changes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "changeable_id"
-    t.string   "changeable_type"
-    t.integer  "user_id"
-    t.string   "change_type"
-    t.text     "updated_attributes", limit: 65535
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.index ["changeable_id"], name: "index_fae_changes_on_changeable_id", using: :btree
-    t.index ["changeable_type"], name: "index_fae_changes_on_changeable_type", using: :btree
-    t.index ["user_id"], name: "index_fae_changes_on_user_id", using: :btree
+  create_table "fae_changes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "changeable_id"
+    t.string "changeable_type"
+    t.integer "user_id"
+    t.string "change_type"
+    t.text "updated_attributes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["changeable_id"], name: "index_fae_changes_on_changeable_id"
+    t.index ["changeable_type"], name: "index_fae_changes_on_changeable_type"
+    t.index ["user_id"], name: "index_fae_changes_on_user_id"
   end
 
-  create_table "fae_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.string   "asset"
-    t.integer  "fileable_id"
-    t.string   "fileable_type"
-    t.integer  "file_size"
-    t.integer  "position",      default: 0
-    t.string   "attached_as"
-    t.boolean  "on_stage",      default: true
-    t.boolean  "on_prod",       default: false
+  create_table "fae_files", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "asset"
+    t.string "fileable_type"
+    t.integer "fileable_id"
+    t.integer "file_size"
+    t.integer "position", default: 0
+    t.string "attached_as"
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "required",      default: false
-    t.index ["attached_as"], name: "index_fae_files_on_attached_as", using: :btree
-    t.index ["fileable_type", "fileable_id"], name: "index_fae_files_on_fileable_type_and_fileable_id", using: :btree
+    t.boolean "required", default: false
+    t.index ["attached_as"], name: "index_fae_files_on_attached_as"
+    t.index ["fileable_type", "fileable_id"], name: "index_fae_files_on_fileable_type_and_fileable_id"
   end
 
-  create_table "fae_images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.string   "asset"
-    t.integer  "imageable_id"
-    t.string   "imageable_type"
-    t.string   "alt"
-    t.string   "caption"
-    t.integer  "position",       default: 0
-    t.string   "attached_as"
-    t.boolean  "on_stage",       default: true
-    t.boolean  "on_prod",        default: false
+  create_table "fae_images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "asset"
+    t.string "imageable_type"
+    t.integer "imageable_id"
+    t.string "alt"
+    t.string "caption"
+    t.integer "position", default: 0
+    t.string "attached_as"
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "file_size"
-    t.boolean  "required",       default: false
-    t.index ["attached_as"], name: "index_fae_images_on_attached_as", using: :btree
-    t.index ["imageable_type", "imageable_id"], name: "index_fae_images_on_imageable_type_and_imageable_id", using: :btree
+    t.integer "file_size"
+    t.boolean "required", default: false
+    t.index ["attached_as"], name: "index_fae_images_on_attached_as"
+    t.index ["imageable_type", "imageable_id"], name: "index_fae_images_on_imageable_type_and_imageable_id"
   end
 
-  create_table "fae_options", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "title"
-    t.string   "time_zone"
-    t.string   "colorway"
-    t.string   "stage_url"
-    t.string   "live_url"
-    t.integer  "singleton_guard"
+  create_table "fae_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.string "time_zone"
+    t.string "colorway"
+    t.string "stage_url"
+    t.string "live_url"
+    t.integer "singleton_guard"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["singleton_guard"], name: "index_fae_options_on_singleton_guard", unique: true, using: :btree
+    t.index ["singleton_guard"], name: "index_fae_options_on_singleton_guard", unique: true
   end
 
-  create_table "fae_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.integer  "position"
+  create_table "fae_roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "fae_static_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "title"
-    t.integer  "position",   default: 0
-    t.boolean  "on_stage",   default: true
-    t.boolean  "on_prod",    default: false
+  create_table "fae_static_pages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.integer "position", default: 0
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "slug"
-    t.index ["slug"], name: "index_fae_static_pages_on_slug", using: :btree
+    t.string "slug"
+    t.index ["slug"], name: "index_fae_static_pages_on_slug"
   end
 
-  create_table "fae_text_areas", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "label"
-    t.text     "content",          limit: 65535
-    t.integer  "position",                       default: 0
-    t.boolean  "on_stage",                       default: true
-    t.boolean  "on_prod",                        default: false
+  create_table "fae_text_areas", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "label"
+    t.text "content"
+    t.integer "position", default: 0
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "contentable_id"
-    t.string   "contentable_type"
-    t.string   "attached_as"
-    t.index ["attached_as"], name: "index_fae_text_areas_on_attached_as", using: :btree
-    t.index ["contentable_id"], name: "index_fae_text_areas_on_contentable_id", using: :btree
-    t.index ["contentable_type"], name: "index_fae_text_areas_on_contentable_type", using: :btree
-    t.index ["on_prod"], name: "index_fae_text_areas_on_on_prod", using: :btree
-    t.index ["on_stage"], name: "index_fae_text_areas_on_on_stage", using: :btree
-    t.index ["position"], name: "index_fae_text_areas_on_position", using: :btree
+    t.integer "contentable_id"
+    t.string "contentable_type"
+    t.string "attached_as"
+    t.index ["attached_as"], name: "index_fae_text_areas_on_attached_as"
+    t.index ["contentable_id"], name: "index_fae_text_areas_on_contentable_id"
+    t.index ["contentable_type"], name: "index_fae_text_areas_on_contentable_type"
+    t.index ["on_prod"], name: "index_fae_text_areas_on_on_prod"
+    t.index ["on_stage"], name: "index_fae_text_areas_on_on_stage"
+    t.index ["position"], name: "index_fae_text_areas_on_position"
   end
 
-  create_table "fae_text_fields", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "contentable_id"
-    t.string   "contentable_type"
-    t.string   "attached_as"
-    t.string   "label"
-    t.string   "content"
-    t.integer  "position",         default: 0
-    t.boolean  "on_stage",         default: true
-    t.boolean  "on_prod",          default: false
+  create_table "fae_text_fields", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "contentable_type"
+    t.integer "contentable_id"
+    t.string "attached_as"
+    t.string "label"
+    t.string "content"
+    t.integer "position", default: 0
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["attached_as"], name: "index_fae_text_fields_on_attached_as", using: :btree
-    t.index ["contentable_type", "contentable_id"], name: "index_fae_text_fields_on_contentable_type_and_contentable_id", using: :btree
-    t.index ["on_prod"], name: "index_fae_text_fields_on_on_prod", using: :btree
-    t.index ["on_stage"], name: "index_fae_text_fields_on_on_stage", using: :btree
-    t.index ["position"], name: "index_fae_text_fields_on_position", using: :btree
+    t.index ["attached_as"], name: "index_fae_text_fields_on_attached_as"
+    t.index ["contentable_type", "contentable_id"], name: "index_fae_text_fields_on_contentable_type_and_contentable_id"
+    t.index ["on_prod"], name: "index_fae_text_fields_on_on_prod"
+    t.index ["on_stage"], name: "index_fae_text_fields_on_on_stage"
+    t.index ["position"], name: "index_fae_text_fields_on_position"
   end
 
-  create_table "fae_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+  create_table "fae_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.string   "confirmation_token"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
-    t.integer  "failed_attempts",        default: 0,  null: false
-    t.string   "unlock_token"
+    t.string "unconfirmed_email"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
     t.datetime "locked_at"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.integer  "role_id"
-    t.boolean  "active"
+    t.string "first_name"
+    t.string "last_name"
+    t.integer "role_id"
+    t.boolean "active"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "language"
-    t.index ["confirmation_token"], name: "index_fae_users_on_confirmation_token", unique: true, using: :btree
-    t.index ["email"], name: "index_fae_users_on_email", unique: true, using: :btree
-    t.index ["reset_password_token"], name: "index_fae_users_on_reset_password_token", unique: true, using: :btree
-    t.index ["role_id"], name: "index_fae_users_on_role_id", using: :btree
-    t.index ["unlock_token"], name: "index_fae_users_on_unlock_token", unique: true, using: :btree
+    t.string "language"
+    t.index ["confirmation_token"], name: "index_fae_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_fae_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_fae_users_on_reset_password_token", unique: true
+    t.index ["role_id"], name: "index_fae_users_on_role_id"
+    t.index ["unlock_token"], name: "index_fae_users_on_unlock_token", unique: true
   end
 
-  create_table "jerseys", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.string   "color"
+  create_table "jerseys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "color"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "locations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.integer  "contact_id"
+  create_table "locations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.integer "contact_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["contact_id"], name: "index_locations_on_contact_id", using: :btree
+    t.index ["contact_id"], name: "index_locations_on_contact_id"
   end
 
-  create_table "milestones", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "year"
-    t.string   "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+  create_table "milestones", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "year"
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "people", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
+  create_table "people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "event_id"
-    t.boolean  "on_stage",   default: true
-    t.boolean  "on_prod",    default: false
-    t.integer  "position"
+    t.integer "event_id"
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
+    t.integer "position"
   end
 
-  create_table "players", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "number"
-    t.text     "bio",        limit: 65535
-    t.integer  "team_id"
+  create_table "players", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "number"
+    t.text "bio"
+    t.integer "team_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["team_id"], name: "index_players_on_team_id", using: :btree
+    t.index ["team_id"], name: "index_players_on_team_id"
   end
 
-  create_table "release_notes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "title"
-    t.text     "body",       limit: 65535
-    t.integer  "position"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.integer  "release_id"
-    t.index ["release_id"], name: "index_release_notes_on_release_id", using: :btree
+  create_table "release_notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "release_id"
+    t.index ["release_id"], name: "index_release_notes_on_release_id"
   end
 
-  create_table "release_selling_points", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "release_id"
-    t.integer  "selling_point_id"
-    t.integer  "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "releases", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.string   "slug"
-    t.text     "intro",             limit: 65535
-    t.text     "body",              limit: 65535
-    t.string   "vintage"
-    t.string   "price"
-    t.string   "tasting_notes_pdf"
-    t.integer  "wine_id"
-    t.integer  "varietal_id"
-    t.boolean  "on_stage",                        default: true
-    t.boolean  "on_prod",                         default: false
-    t.integer  "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "video_url"
-    t.boolean  "featured"
-    t.string   "weight"
-    t.date     "release_date"
-    t.date     "show"
-    t.date     "hide"
-    t.text     "description",       limit: 65535
-    t.text     "content",           limit: 65535
-    t.string   "seo_title"
-    t.string   "seo_description"
-    t.string   "color"
-  end
-
-  create_table "selling_points", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.boolean  "on_stage",   default: true
-    t.boolean  "on_prod",    default: false
-    t.integer  "position"
+  create_table "release_selling_points", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "release_id"
+    t.integer "selling_point_id"
+    t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "teams", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.string   "city"
-    t.text     "history",    limit: 65535
+  create_table "releases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "slug"
+    t.text "intro"
+    t.text "body"
+    t.string "vintage"
+    t.string "price"
+    t.string "tasting_notes_pdf"
+    t.integer "wine_id"
+    t.integer "varietal_id"
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
+    t.integer "position"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "video_url"
+    t.boolean "featured"
+    t.string "weight"
+    t.date "release_date"
+    t.date "show"
+    t.date "hide"
+    t.text "description"
+    t.text "content"
+    t.string "seo_title"
+    t.string "seo_description"
+    t.string "color"
+  end
+
+  create_table "selling_points", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
+    t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "validation_testers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.string   "slug"
-    t.string   "second_slug"
-    t.string   "email"
-    t.string   "url"
-    t.string   "phone"
-    t.string   "zip"
-    t.string   "canadian_zip"
-    t.string   "youtube_url"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
-    t.string   "second_email"
-    t.string   "unique_email"
-    t.string   "second_url"
-    t.string   "second_phone"
-    t.string   "second_zip"
-    t.string   "second_youtube_url"
-  end
-
-  create_table "varietals", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.boolean  "on_stage",   default: true
-    t.boolean  "on_prod",    default: false
-    t.integer  "position"
+  create_table "teams", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "city"
+    t.text "history"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "winemakers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.integer  "position"
-    t.integer  "wine_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.integer  "region_type"
-    t.index ["wine_id"], name: "index_winemakers_on_wine_id", using: :btree
+  create_table "validation_testers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "slug"
+    t.string "second_slug"
+    t.string "email"
+    t.string "url"
+    t.string "phone"
+    t.string "zip"
+    t.string "canadian_zip"
+    t.string "youtube_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "second_email"
+    t.string "unique_email"
+    t.string "second_url"
+    t.string "second_phone"
+    t.string "second_zip"
+    t.string "second_youtube_url"
   end
 
-  create_table "wines", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name_en"
-    t.boolean  "on_stage",                      default: true
-    t.boolean  "on_prod",                       default: false
-    t.integer  "position"
+  create_table "varietals", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
+    t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name_zh"
-    t.string   "name_ja"
-    t.text     "description_en",  limit: 65535
-    t.text     "description_zh",  limit: 65535
-    t.text     "description_ja",  limit: 65535
-    t.text     "food_pairing_en", limit: 65535
-    t.text     "food_pairing_zh", limit: 65535
-    t.text     "food_pairing_ja", limit: 65535
   end
 
+  create_table "winemakers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.integer "position"
+    t.integer "wine_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "region_type"
+    t.index ["wine_id"], name: "index_winemakers_on_wine_id"
+  end
+
+  create_table "wines", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name_en"
+    t.boolean "on_stage", default: true
+    t.boolean "on_prod", default: false
+    t.integer "position"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "name_zh"
+    t.string "name_ja"
+    t.text "description_en"
+    t.text "description_zh"
+    t.text "description_ja"
+    t.text "food_pairing_en"
+    t.text "food_pairing_zh"
+    t.text "food_pairing_ja"
+  end
+
+  add_foreign_key "articles", "article_categories"
 end


### PR DESCRIPTION
These were missing in the dummy, preventing `rake db:migrate` to run.