### PR TITLE
80330 security fixes

### DIFF
--- a/app/controllers/fae/utilities_controller.rb
+++ b/app/controllers/fae/utilities_controller.rb
@@ -2,8 +2,9 @@ module Fae
   class UtilitiesController < ApplicationController
 
     def toggle
-      klass = params[:object].gsub('__', '/').classify.constantize
+      klass = params[:object].gsub('__', '/').classify
       if can_toggle(klass, params[:attr])
+        klass = klass.constantize
         klass.find(params[:id]).toggle(params[:attr]).save(validate: false)
         render body: nil
       else
@@ -43,6 +44,10 @@ module Fae
     private
 
     def can_toggle(klass, attribute)
+      # check if class exists and convert
+      return false unless Object.const_defined?(klass)
+      klass = klass.constantize
+
       # allow admins to toggle Fae::User#active
       return true if klass == Fae::User && attribute == 'active' && current_user.super_admin_or_admin?
 

--- a/app/controllers/fae/utilities_controller.rb
+++ b/app/controllers/fae/utilities_controller.rb
@@ -3,7 +3,7 @@ module Fae
 
     def toggle
       klass = params[:object].gsub('__', '/').classify.constantize
-      if can_toggle(klass)
+      if can_toggle(klass, params[:attr])
         klass.find(params[:id]).toggle(params[:attr]).save(validate: false)
         render body: nil
       else
@@ -42,10 +42,17 @@ module Fae
 
     private
 
-    def can_toggle(klass)
-      # restrict models that non-admins aren't allowed to update
-      restricted_classes = %w(Fae::User Fae::Role Fae::Option)
-      return false if restricted_classes.include?(klass.name.to_s) && !current_user.super_admin_or_admin?
+    def can_toggle(klass, attribute)
+      # allow admins to toggle Fae::User#active
+      return true if klass == Fae::User && attribute == 'active' && current_user.super_admin_or_admin?
+
+      # restrict models that only super admins can toggle
+      restricted_classes = %w(Fae::User Fae::Role Fae::Option Fae::Change)
+      return false if restricted_classes.include?(klass.name.to_s) && !current_user.super_admin?
+
+      # restrict to only other boolean fields
+      return false unless klass.columns_hash[attribute].type == :boolean
+
       true
     end
 

--- a/app/models/fae/user.rb
+++ b/app/models/fae/user.rb
@@ -5,9 +5,9 @@ module Fae
     include Fae::UserConcern
 
     # Include default devise modules. Others available are:
-    # :registerable, :confirmable, :lockable, :timeoutable and :omniauthable
+    # :registerable, :confirmable, :timeoutable and :omniauthable
     devise :database_authenticatable,
-           :recoverable, :rememberable, :trackable
+           :recoverable, :rememberable, :trackable, :lockable
 
     belongs_to :role
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -156,27 +156,27 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [ :email ]
+  config.unlock_keys = [ :email ]
 
   # Defines which strategy will be used to unlock an account.
   # :email = Sends an unlock link to the user email
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :both
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 5
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = false
+  config.last_attempt_warning = true
 
   # ==> Configuration for :recoverable
   #

--- a/spec/requests/fae/utilites_spec.rb
+++ b/spec/requests/fae/utilites_spec.rb
@@ -5,7 +5,7 @@ describe 'utilities#toggle' do
   context 'when role is user' do
     it "shouldn't be able to toggle user's active attr" do
       user_login
-      post '/admin/toggle/fae__users/1/active', as: :js
+      post "/admin/toggle/fae__users/#{Fae::User.first.id}/active", as: :js
 
       expect(response.status).to eq(401)
     end
@@ -17,13 +17,30 @@ describe 'utilities#toggle' do
 
       expect(response.status).to eq(200)
     end
+
+    it "shouldn be able to toggle non-boolean attrs" do
+      user_login
+      release = FactoryGirl.create(:release)
+      post "/admin/toggle/releases/#{release.id}/wine_id", as: :json
+
+      expect(response.status).to eq(401)
+    end
+  end
+
+  context 'when role is admin' do
+    it "shouldn't be able to elevate privaledges" do
+      admin_login
+      post "/admin/toggle/fae__users/#{Fae::User.first.id}/role_id", as: :js
+
+      expect(response.status).to eq(401)
+    end
   end
 
   context 'when logged out' do
     it "shouldn't be able to toggle user's active attr" do
       create_super_user
 
-      post '/admin/toggle/fae_users/1/active', as: :js
+      post "/admin/toggle/fae_users/#{Fae::User.first.id}/active", as: :js
       follow_redirect!
 
       expect(response.body).to include(I18n.t(:devise)[:failure][:unauthenticated])

--- a/spec/requests/fae/utilites_spec.rb
+++ b/spec/requests/fae/utilites_spec.rb
@@ -10,7 +10,7 @@ describe 'utilities#toggle' do
       expect(response.status).to eq(401)
     end
 
-    it "shouldn be able to toggle release's on_prod attr" do
+    it "shouldn't be able to toggle release's on_prod attr" do
       user_login
       release = FactoryGirl.create(:release)
       post "/admin/toggle/releases/#{release.id}/on_prod", as: :json
@@ -18,10 +18,17 @@ describe 'utilities#toggle' do
       expect(response.status).to eq(200)
     end
 
-    it "shouldn be able to toggle non-boolean attrs" do
+    it "shouldn't be able to toggle non-boolean attrs" do
       user_login
       release = FactoryGirl.create(:release)
       post "/admin/toggle/releases/#{release.id}/wine_id", as: :json
+
+      expect(response.status).to eq(401)
+    end
+
+    it "should't expose missing classes" do
+      user_login
+      post "/admin/toggle/not_a_class/1/on_prod", as: :json
 
       expect(response.status).to eq(401)
     end


### PR DESCRIPTION
**Prevent vertical privilege escalation**
Users with the role of admins could potentially set their role as super admin by abusing the `toggle` method provided for boolean attributes. Stricter definitions were added to `toggle` to make sure this doesn't happen. 

**More toggle abuse**
`toggle` could also be used to on non-boolean attributes, which could lead to other potential security issues. Method is now available for booleans only.

`toggle` also exposed the existence of classes but returning a 500 when a class did not exist. Missing classes now return a 401 inline with unauthorized classes.

**Brute-force protection**
Currently Fae has no brute-force protection. This also enables Devise's lockable feature which will lock accounts after 5 failed attempts to log in. Accounts unlock after an hour or via emailed instructions.