### PR TITLE
Optional add button for nested tables

### DIFF
--- a/app/views/fae/shared/_nested_table.html.slim
+++ b/app/views/fae/shared/_nested_table.html.slim
@@ -11,6 +11,7 @@ ruby:
   assoc_name          ||= assoc.to_s                      # 'restaurant_bars'
   title               ||= assoc_name.titleize             # 'Restaurant Bars'
   add_button_text     ||= t('fae.common.add', title: title.singularize)
+  hide_add_button     ||= false
   ordered             ||= false
   has_thumb           ||= false
   edit_column         ||= false
@@ -41,7 +42,8 @@ section.addedit-form.js-addedit-form class="#{'content' if index}"
     == render 'fae/shared/shared_nested_table', options_for_table
 
   - else
-    a.js-add-link.table-add-link.button.-small href=new_path = add_button_text
+    - unless hide_add_button
+      a.js-add-link.table-add-link.button.-small href=new_path = add_button_text
     h2 = title
     - if helper_text.present?
       h6.table-helper-text = helper_text

--- a/app/views/fae/shared/_nested_table.html.slim
+++ b/app/views/fae/shared/_nested_table.html.slim
@@ -34,7 +34,7 @@ ruby:
     new_path += "item_id=#{parent_item.id}&=item_class=#{parent_item.class.to_s}"
   end
 
-  options_for_table = { index: index, assoc: assoc, assoc_name: assoc_name, title: title, add_button_text: add_button_text, ordered: ordered, has_thumb: has_thumb, edit_column: edit_column, cols: cols, assoc_name_singular: assoc_name_singular, new_path: new_path, edit_path: edit_path }
+  options_for_table = { index: index, assoc: assoc, assoc_name: assoc_name, title: title, add_button_text: add_button_text, hide_add_button: hide_add_button, ordered: ordered, has_thumb: has_thumb, edit_column: edit_column, cols: cols, assoc_name_singular: assoc_name_singular, new_path: new_path, edit_path: edit_path }
   options_for_table[:parent_item] = parent_item unless index
 
 section.addedit-form.js-addedit-form class="#{'content' if index}"

--- a/app/views/fae/shared/_shared_nested_table.html.slim
+++ b/app/views/fae/shared/_shared_nested_table.html.slim
@@ -37,10 +37,13 @@ table class=table_class
                 i.icon-edit
           td = fae_delete_button item, "/#{fae_path}/#{assoc_name}/#{item.id.to_s}", class: 'js-tooltip table-action js-delete-link', remote: true
 
-    - else
+    - elsif !hide_add_button
       tr
         - td_link = link_to 'add some', new_path, class: 'js-add-link'
 
         td colspan=colspan.to_s No #{title} yet, #{td_link}.
+    - else
+      tr
+        td colspan=colspan.to_s No #{title} yet.
 
 .js-addedit-form-wrapper

--- a/docs/helpers/partials.md
+++ b/docs/helpers/partials.md
@@ -97,13 +97,13 @@ The nested_table should go after the main form ends and should only be placed on
 
 | option | type | default | description |
 |--------|------|---------|-------------|
-| index | false | boolean | used for nested index forms |
+| index | boolean | false | used for nested index forms |
 | assoc   | symbol | | **(required)** the association's name, or the item's name if it's for the index  |
 | parent_item | ActiveRecord object | | **(required)** the item that the new objects will be associated to  |
 | cols* | array of symbols, or array of symbols and hashes | [], [{}] | an array of attributes to display on the list view, associations will display the `fae_display_field` or a thumbnail if it's a `Fae::Image` |
 | title | string | assoc.to_s.titleize | the H3 directly above the form |
 | add_button_text | string | "Add #{title.singularize}" | the add button's text |
-| hide_add_button | false | boolean | Disables the Add button in the table header and the "add some" link in the table body |
+| hide_add_button | boolean | false | Disables the Add button in the table header and the "add some" link in the table body |
 | ordered | boolean | false | allows list view to be sortable, which is saved to a `position` attribute |
 | has_thumb | boolean | false | displays a thumbnail in the list view (only applicable to `Fae::Image`)
 | edit_column | boolean | false | displays edit link

--- a/docs/helpers/partials.md
+++ b/docs/helpers/partials.md
@@ -103,6 +103,7 @@ The nested_table should go after the main form ends and should only be placed on
 | cols* | array of symbols, or array of symbols and hashes | [], [{}] | an array of attributes to display on the list view, associations will display the `fae_display_field` or a thumbnail if it's a `Fae::Image` |
 | title | string | assoc.to_s.titleize | the H3 directly above the form |
 | add_button_text | string | "Add #{title.singularize}" | the add button's text |
+| hide_add_button | false | boolean | Disables the Add button in the table header and the "add some" link in the table body |
 | ordered | boolean | false | allows list view to be sortable, which is saved to a `position` attribute |
 | has_thumb | boolean | false | displays a thumbnail in the list view (only applicable to `Fae::Image`)
 | edit_column | boolean | false | displays edit link


### PR DESCRIPTION
Related to https://github.com/wearefine/fae/issues/496

Found that this was a pretty simple change to add an optional argument that can be used to disable the add button and the "add some" link on a nested table. This should be a lot faster and easier to use than creating a custom table just to override the default behavior.