### PR TITLE
Show flash alert for static page errors for file or image upload fields

### DIFF
--- a/app/controllers/fae/static_pages_controller.rb
+++ b/app/controllers/fae/static_pages_controller.rb
@@ -20,7 +20,8 @@ module Fae
         redirect_to @index_path, notice: t('fae.save_notice')
       else
         build_assocs
-        render template: "#{fae.root_path.gsub('/', '')}/content_blocks/#{params[:slug]}", error: t('fae.save_error')
+        flash[:alert] = t('fae.save_error')
+        render template: "#{fae.root_path.gsub('/', '')}/content_blocks/#{params[:slug]}"
       end
     end
 


### PR DESCRIPTION
This change fixes an issue where the error flash alert would not be displayed when a required image or file upload field was left empty and the form was submitted. Normal input fields trigger a front end validation error and prevent the submit, but image/file uploads need to hit the server to validate presence. The flash alert needed to be set before the render template action.

Related to issues 69768 and 68584

> "You can see it on any fae::page with a required image."
> 
> 1) form pages aren't showing the "let's slow down a bit" message at the top.
> 2) the form submits and redirects to update action with errors instead of the submit just getting blocked by judge. could this be by design because of the nature of the page model?
> 