### PR TITLE
Add support for adding db indexes via fae:scaffold generator

### DIFF
--- a/lib/generators/fae/base_generator.rb
+++ b/lib/generators/fae/base_generator.rb
@@ -26,7 +26,7 @@ module Fae
           if is_attachment(arg)
             @@attachments << arg
           else
-            @@attributes_flat << "#{arg.name}:#{arg.type}"
+            @@attributes_flat << "#{arg.name}:#{arg.type}" + (arg.has_index? ? ":index" : "")
           end
 
           if is_association(arg)


### PR DESCRIPTION
Currently, running `rails g fae:scaffold TestItem some_attribute:string:index` causes the base generator to only generates the model and migration with the attribute name and type. This change gets the base generator to include and pass along the :index arg when generating a new model via the generate fae:scaffold task so you don't have to add another migration to add indexes after the fact.

I'm using this change running the fae gem locally with my spec importer rake task and it's working great to create new models with the usual indexes for slug, position, on_prod/stage attrs included from the get go.