### PR TITLE
77538 - fae_checkbox form helper updates

### DIFF
--- a/app/helpers/fae/form_helper.rb
+++ b/app/helpers/fae/form_helper.rb
@@ -50,7 +50,8 @@ module Fae
 
     def fae_checkbox(f, attribute, options={})
       options[:type] ||= 'stacked'
-      options.update(as: :check_boxes, wrapper_class: "checkbox-wrapper js-checkbox-wrapper #{options[:wrapper_class]} -#{options[:type]}", no_label_div: true)
+      options[:input_type] ||= :check_boxes
+      options.update(as: options[:input_type], wrapper_class: "input checkbox-wrapper js-checkbox-wrapper #{options[:wrapper_class]} -#{options[:type]}", no_label_div: true)
       association_or_input f, attribute, options
     end
 

--- a/docs/helpers/form_helpers.md
+++ b/docs/helpers/form_helpers.md
@@ -116,12 +116,13 @@ fae_checkbox
 | option | type | default | description |
 | ------ | ---- | ------- | ----------- |
 | type | 'stacked' or 'inline' | stacked | determines how multiple checkboxes are displayed |
+| input_type | :boolean or :check_boxes | :check_boxes | use :boolean for single true/false input
 
 **Examples**
 
-A single attribute checkbox
+A single attribute checkbox to save a boolean
 ```ruby
-fae_checkbox f, :active
+fae_checkbox f, :active, input_type: :boolean
 ```
 
 Inline has_many collection of checkboxes


### PR DESCRIPTION
Updates the fae_checkbox helper to accept an optional input_type arg to make it behave as a single boolean input. Sometimes we just want a single boolean checkbox field instead of the default multi checkbox option format.

See FINE Redmine issue 77538 for additional detail.