### PR TITLE
Adds highlight color admin control in root settings

### DIFF
--- a/app/assets/stylesheets/fae/globals/_tags.scss
+++ b/app/assets/stylesheets/fae/globals/_tags.scss
@@ -33,7 +33,7 @@ body {
 
 a {
   @include transition(color .2s);
-  color: $c-custom-highlight;
+  color: var(--highlight-color);
   text-decoration: none;
 
   &:hover {

--- a/app/assets/stylesheets/fae/globals/imports/_variables.scss
+++ b/app/assets/stylesheets/fae/globals/imports/_variables.scss
@@ -1,6 +1,9 @@
 //////////////////////////////
 // Project Specific Variables
 //////////////////////////////
+:root {
+  --highlight-color: #9aa142;
+}
 
 // Empty variable for user-defined breakpoints
 $custom-breakpoints: () !default;
@@ -25,7 +28,7 @@ $header-border-width: 4px !default;
 $f-content: 'Lato', $f-sans !default;
 
 // Apps should declare $c-custom-highlight in their fae.scss file
-$c-custom-highlight: #9aa142 !default;
+$c-custom-highlight:  var(--highlight-color);
 
 // In order from dark to light
 // These are stacked in 10s so new colors can be easily inserted between if/when this list changes

--- a/app/assets/stylesheets/fae/globals/imports/_variables.scss
+++ b/app/assets/stylesheets/fae/globals/imports/_variables.scss
@@ -25,8 +25,7 @@ $header-border-width: 4px !default;
 $f-content: 'Lato', $f-sans !default;
 
 // Apps should declare $c-custom-highlight in their fae.scss file
-$c-custom-highlight: <%= Fae::Option.first.highlight_color || '#9aa142' %>;
-// 9aa142 Default
+$c-custom-highlight: #9aa142 !default;
 
 // In order from dark to light
 // These are stacked in 10s so new colors can be easily inserted between if/when this list changes

--- a/app/assets/stylesheets/fae/globals/imports/_variables.scss.erb
+++ b/app/assets/stylesheets/fae/globals/imports/_variables.scss.erb
@@ -25,7 +25,8 @@ $header-border-width: 4px !default;
 $f-content: 'Lato', $f-sans !default;
 
 // Apps should declare $c-custom-highlight in their fae.scss file
-$c-custom-highlight: #9aa142 !default;
+$c-custom-highlight: <%= Fae::Option.first.highlight_color || '#9aa142' %>;
+// 9aa142 Default
 
 // In order from dark to light
 // These are stacked in 10s so new colors can be easily inserted between if/when this list changes

--- a/app/assets/stylesheets/fae/globals/layout/_base.scss
+++ b/app/assets/stylesheets/fae/globals/layout/_base.scss
@@ -28,7 +28,7 @@
   h2 {
     padding: 17px $content-buffer;
     color: pickForegroundColor($c-custom-highlight, $c-white, $c-black);
-    background: $c-custom-highlight;
+    background: var(--highlight-color);
     border-top: 1px solid $c-border;
     text-transform: uppercase;
     font-size: 14px;

--- a/app/assets/stylesheets/fae/globals/layout/_content-header.scss
+++ b/app/assets/stylesheets/fae/globals/layout/_content-header.scss
@@ -50,7 +50,7 @@ $content-header-padding: 16px;
 
     &:hover {
       color: $c-text-heavy;
-      border-bottom-color: $c-custom-highlight;
+      border-bottom-color: var(--highlight-color);
     }
   }
 
@@ -67,7 +67,7 @@ $content-header-padding: 16px;
     &.-active {
       a {
         color: $c-text-heavy;
-        border-bottom-color: $c-custom-highlight;
+        border-bottom-color: var(--highlight-color);
       }
     }
   }

--- a/app/assets/stylesheets/fae/globals/legacy/_pre-1.3.scss
+++ b/app/assets/stylesheets/fae/globals/legacy/_pre-1.3.scss
@@ -80,7 +80,7 @@
 .main_content-section-title {
   padding: 17px 40px;
   color: pickForegroundColor($c-custom-highlight, $c-white, $c-black);
-  background: $c-custom-highlight;;
+  background: var(--highlight-color);  
   border-top: 1px solid $c-border;
   text-transform: uppercase;
   font-size: 14px;
@@ -166,7 +166,7 @@ tbody {
 
       &.active,
       &:hover {
-        background: $c-custom-highlight;
+        background: var(--highlight-color);
         color: $c-white;
       }
     }
@@ -341,7 +341,7 @@ tbody {
 
     &:hover {
       color: $c-text-heavy;
-      border-bottom-color: $c-custom-highlight;
+      border-bottom-color: var(--highlight-color);
     }
   }
 
@@ -358,7 +358,7 @@ tbody {
     &.-active {
       a {
         color: $c-text-heavy;
-        border-bottom-color: $c-custom-highlight;
+        border-bottom-color: var(--highlight-color);
       }
     }
   }
@@ -418,7 +418,7 @@ tbody {
   li {
     padding: 7px 20px;
     font-size: 14px;
-    color: $c-custom-highlight;
+    color: var(--highlight-color);
     cursor: pointer;
 
     &:hover {

--- a/app/assets/stylesheets/fae/globals/navigation/_footer.scss
+++ b/app/assets/stylesheets/fae/globals/navigation/_footer.scss
@@ -32,7 +32,7 @@
 
     &:hover {
       path {
-        fill: $c-custom-highlight;
+        fill: var(--highlight-color);
       }
     }
   }

--- a/app/assets/stylesheets/fae/globals/navigation/_header.scss
+++ b/app/assets/stylesheets/fae/globals/navigation/_header.scss
@@ -6,7 +6,7 @@
   left: 0;
   width: 100%;
   background: $c-header-bg;
-  border-bottom: $header-border-width solid $c-custom-highlight;
+  border-bottom: $header-border-width solid var(--highlight-color);
 
   @include bp(large) {
     padding: 0 $content-buffer;
@@ -107,7 +107,7 @@
 
     &.-parent-current {
       > a {
-        background: $c-custom-highlight;
+        background: var(--highlight-color);
       }
     }
 

--- a/app/assets/stylesheets/fae/globals/navigation/_utility.scss
+++ b/app/assets/stylesheets/fae/globals/navigation/_utility.scss
@@ -73,7 +73,7 @@
   height: 40px;
   display: inline-block;
   vertical-align: middle;
-  background: $c-custom-highlight;
+  background: var(--highlight-color);
 }
 
 .grabatar-link {

--- a/app/assets/stylesheets/fae/modules/_toggles.scss
+++ b/app/assets/stylesheets/fae/modules/_toggles.scss
@@ -44,5 +44,5 @@
 
 .slider-option-yes {
   color: $c-white;
-  background: $c-custom-highlight;
+  background: var(--highlight-color);
 }

--- a/app/assets/stylesheets/fae/modules/forms/_date.scss
+++ b/app/assets/stylesheets/fae/modules/forms/_date.scss
@@ -149,11 +149,11 @@
 
 .ui-datepicker-calendar {
   .ui-state-hover {
-    color: $c-custom-highlight;
+    color: var(--highlight-color);
   }
 
   .ui-state-active {
-    background: $c-custom-highlight;
+    background: var(--highlight-color);
     color: $c-white;
     position: relative;
   }
@@ -323,12 +323,12 @@
 
         &.checked,
         &.toMonth.valid.checked {
-          background: $c-custom-highlight;
+          background: var(--highlight-color);
           color: $c-white;
         }
 
         &.real-today.checked {
-          background: $c-custom-highlight;
+          background: var(--highlight-color);
         }
       }
 

--- a/app/assets/stylesheets/fae/modules/forms/_label.scss
+++ b/app/assets/stylesheets/fae/modules/forms/_label.scss
@@ -6,7 +6,7 @@ label {
   color: $c-text-heavy;
 
   abbr {
-    color: $c-custom-highlight;
+    color: var(--highlight-color);
   }
 
   h6 {

--- a/app/assets/stylesheets/fae/modules/forms/_select.scss
+++ b/app/assets/stylesheets/fae/modules/forms/_select.scss
@@ -227,7 +227,7 @@
           position: absolute;
           right: 15px;
           top: 9px;
-          color: $c-custom-highlight;
+          color: var(--highlight-color);
         }
       }
 
@@ -288,7 +288,7 @@
           content: fae-icon(check);
           padding-right: 5px;
           margin-left: -19px;
-          color: $c-custom-highlight;
+          color: var(--highlight-color);
         }
       }
 

--- a/app/assets/stylesheets/fae/modules/tables/_base.scss
+++ b/app/assets/stylesheets/fae/modules/tables/_base.scss
@@ -22,7 +22,7 @@ tbody {
     &:hover {
       td {
         &:first-child {
-          border-left-color: $c-custom-highlight;
+          border-left-color: var(--highlight-color);
         }
       }
     }

--- a/app/assets/stylesheets/fae/modules/tables/_pagination.scss
+++ b/app/assets/stylesheets/fae/modules/tables/_pagination.scss
@@ -19,7 +19,7 @@
 
     &:hover {
       color: $c-white;
-      background: $c-custom-highlight;
+      background: var(--highlight-color);
     }
   }
 
@@ -29,6 +29,6 @@
 
   .current {
     color: $c-white;
-    background: $c-custom-highlight;
+    background: var(--highlight-color);
   }
 }

--- a/app/assets/stylesheets/fae/pages/_error.scss
+++ b/app/assets/stylesheets/fae/pages/_error.scss
@@ -8,7 +8,7 @@
     min-width: 235px;
     height: 330px;
     padding: 35px;
-    border-top: 8px solid $c-custom-highlight;
+    border-top: 8px solid var(--highlight-color);
     border-radius: 4px;
     background: white;
     color: $c-mid-dark-grey;

--- a/app/controllers/fae/options_controller.rb
+++ b/app/controllers/fae/options_controller.rb
@@ -23,7 +23,7 @@ module Fae
 
       # Only allow a trusted parameter "white list" through.
       def option_params
-        params.require(:option).permit(:title, :time_zone, :colorway, :stage_url, :live_url, logo_attributes: [:id, :asset, :asset_cache, :attached_as, :alt], favicon_attributes: [:id, :asset, :asset_cache, :attached_as, :alt])
+        params.require(:option).permit(:title, :highlight_color, :time_zone, :colorway, :stage_url, :live_url, logo_attributes: [:id, :asset, :asset_cache, :attached_as, :alt], favicon_attributes: [:id, :asset, :asset_cache, :attached_as, :alt])
       end
   end
 end

--- a/app/controllers/fae/options_controller.rb
+++ b/app/controllers/fae/options_controller.rb
@@ -12,6 +12,13 @@ module Fae
     # PATCH/PUT /options/1
     def update
       if @option.update(option_params)
+        # add custom css and recompile assets to apply the custom highlight color if changed
+        if option_params[:highlight_color].present?
+          css_text = "$c-custom-highlight: #{option_params[:highlight_color]};"
+          file = File.open('app/assets/stylesheets/highlight_color.scss', 'w') { |f| f << css_text; f.close }
+          system 'rake assets:precompile RAILS_ENV=production'
+          system 'touch tmp/restart.txt'
+        end
         flash[:notice] = 'Option was successfully updated.'
         redirect_to :action => :edit
       else
@@ -21,9 +28,9 @@ module Fae
 
     private
 
-      # Only allow a trusted parameter "white list" through.
-      def option_params
-        params.require(:option).permit(:title, :highlight_color, :time_zone, :colorway, :stage_url, :live_url, logo_attributes: [:id, :asset, :asset_cache, :attached_as, :alt], favicon_attributes: [:id, :asset, :asset_cache, :attached_as, :alt])
-      end
+    # Only allow a trusted parameter "white list" through.
+    def option_params
+      params.require(:option).permit(:title, :highlight_color, :time_zone, :colorway, :stage_url, :live_url, logo_attributes: [:id, :asset, :asset_cache, :attached_as, :alt], favicon_attributes: [:id, :asset, :asset_cache, :attached_as, :alt])
+    end
   end
 end

--- a/app/controllers/fae/options_controller.rb
+++ b/app/controllers/fae/options_controller.rb
@@ -14,14 +14,9 @@ module Fae
       if @option.update(option_params)
         # add custom css and recompile assets to apply the custom highlight color if changed
         if option_params[:highlight_color].present?
-          css_text = "$c-custom-highlight: #{option_params[:highlight_color]};"
-          filepath = 'app/assets/stylesheets/fae.scss'
-          # opens the fae.scss file and substitues the new css string
-          IO.write(filepath, File.open(filepath) do |f|
-            f.read.gsub(/^.*c-custom-highlight.*/, css_text)
-          end)
-          # precompile assets so the css change is visible after updating
-          system 'rake assets:precompile RAILS_ENV=production'
+          hexcolor = option_params[:highlight_color]
+          # TODO need some AJAX to change the root: --highlight-color value like this:
+          # document.querySelector(':root').style.setProperty('--highlight-color', hexcolor)
         end
         flash[:notice] = 'Option was successfully updated.'
         redirect_to :action => :edit

--- a/app/controllers/fae/options_controller.rb
+++ b/app/controllers/fae/options_controller.rb
@@ -15,9 +15,13 @@ module Fae
         # add custom css and recompile assets to apply the custom highlight color if changed
         if option_params[:highlight_color].present?
           css_text = "$c-custom-highlight: #{option_params[:highlight_color]};"
-          file = File.open('app/assets/stylesheets/highlight_color.scss', 'w') { |f| f << css_text; f.close }
+          filepath = 'app/assets/stylesheets/fae.scss'
+          # opens the fae.scss file and substitues the new css string
+          IO.write(filepath, File.open(filepath) do |f|
+            f.read.gsub(/^.*c-custom-highlight.*/, css_text)
+          end)
+          # precompile assets so the css change is visible after updating
           system 'rake assets:precompile RAILS_ENV=production'
-          system 'touch tmp/restart.txt'
         end
         flash[:notice] = 'Option was successfully updated.'
         redirect_to :action => :edit

--- a/app/views/fae/options/_form.html.slim
+++ b/app/views/fae/options/_form.html.slim
@@ -9,6 +9,7 @@
 
   section.content
     = fae_input f, :title, label: t('fae.options.project.name')
+    = fae_input f, :highlight_color, helper_text: 'Enter hex color code as "#9AA142".'
     = fae_input f, :time_zone, wrapper_class: 'select'
     = fae_input f, :live_url, label: t('fae.options.live_url'), helper_text: t('fae.options.url_helper')
     = fae_input f, :stage_url, label: t('fae.options.stage_url'), helper_text: t('fae.options.url_helper')

--- a/db/migrate/20181221233132_add_highlight_color_to_fae_options.rb
+++ b/db/migrate/20181221233132_add_highlight_color_to_fae_options.rb
@@ -1,0 +1,5 @@
+class AddHighlightColorToFaeOptions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :fae_options, :highlight_color, :string
+  end
+end


### PR DESCRIPTION
Fae admins rejoice! For this change allows the highlight color to be changed in the root settings instead of requiring a dev to manually update the fae.scss file with a new hex color.

Note, after incorporating this change you will need to run `rake fae:install:migrations` and then run `rake db:migrate` to get the new column into your app's db.

Related to: FINE Redmine issue 77928