### PR TITLE
Generator fixes for GraphQL Types and some template spacing fixes

### DIFF
--- a/lib/generators/fae/templates/graphql/graphql_page_type.rb
+++ b/lib/generators/fae/templates/graphql/graphql_page_type.rb
@@ -1,4 +1,4 @@
-class Types::<%= class_name %>PageType < Types::BaseObject
+class Types::<%= class_name %>PageType < Types::BaseFaePageType
 
   graphql_name '<%= class_name %>Page'
 

--- a/lib/generators/fae/templates/graphql/graphql_type.rb
+++ b/lib/generators/fae/templates/graphql/graphql_type.rb
@@ -5,7 +5,9 @@ class Types::<%= class_name %>Type < Types::BaseObject
   field :id, ID, null: false
 <% if @graphql_attributes.present? -%>
 <% @graphql_attributes.each do |graphql_object| -%>
+<% if graphql_object[:attr] != :static_page -%>
   field :<%= graphql_object[:attr] %>, <%= graphql_object[:type] %>, null: true
+<% end -%>
 <% end -%>
 <% end -%>
   field :created_at, String, null: false

--- a/lib/generators/fae/templates/views/_form.html.slim
+++ b/lib/generators/fae/templates/views/_form.html.slim
@@ -1,12 +1,12 @@
 ruby:
-	form_options = {
-		html: {
-			data: {
-				form_manager_model: @item.fae_form_manager_model_name,
-				form_manager_info: (@form_manager.present? ? @form_manager.to_json : nil)
-			}
-		}
-	}
+  form_options = {
+    html: {
+      data: {
+        form_manager_model: @item.fae_form_manager_model_name,
+        form_manager_info: (@form_manager.present? ? @form_manager.to_json : nil)
+      }
+    }
+  }
 = simple_form_for(['admin', @item], form_options) do |f|
   == render 'fae/shared/form_header', header: @klass_name
 

--- a/lib/generators/fae/templates/views/_form_index_nested.html.slim
+++ b/lib/generators/fae/templates/views/_form_index_nested.html.slim
@@ -1,17 +1,17 @@
 ruby:
-	form_options = {
-		html: {
-			multipart: true,
-			novalidate: true,
-			class: 'js-file-form',
-			remote: true,
-			data: {
-				type: "html",
-				form_manager_model: @item.fae_form_manager_model_name,
-				form_manager_info: (@form_manager.present? ? @form_manager.to_json : nil)
-			}
-		}
-	}
+  form_options = {
+    html: {
+      multipart: true,
+      novalidate: true,
+      class: 'js-file-form',
+      remote: true,
+      data: {
+        type: "html",
+        form_manager_model: @item.fae_form_manager_model_name,
+        form_manager_info: (@form_manager.present? ? @form_manager.to_json : nil)
+      }
+    }
+  }
 = simple_form_for(['<%= options.namespace %>', @item], form_options) do |f|
 <% @form_attrs.each do |attr| -%>
   = fae_input f, :<%= attr %>

--- a/lib/generators/fae/templates/views/_form_nested.html.slim
+++ b/lib/generators/fae/templates/views/_form_nested.html.slim
@@ -1,17 +1,17 @@
 ruby:
-	form_options = {
-		html: {
-			multipart: true,
-			novalidate: true,
-			class: 'js-file-form',
-			remote: true,
-			data: {
-				type: "html",
-				form_manager_model: @item.fae_form_manager_model_name,
-				form_manager_info: (@form_manager.present? ? @form_manager.to_json : nil)
-			}
-		}
-	}
+  form_options = {
+    html: {
+      multipart: true,
+      novalidate: true,
+      class: 'js-file-form',
+      remote: true,
+      data: {
+        type: "html",
+        form_manager_model: @item.fae_form_manager_model_name,
+        form_manager_info: (@form_manager.present? ? @form_manager.to_json : nil)
+      }
+    }
+  }
 = simple_form_for(['admin', @item], form_options) do |f|
 <% @form_attrs.each do |attr| -%>
   = fae_input f, :<%= attr %>

--- a/lib/generators/fae/templates/views/static_page_form.html.slim
+++ b/lib/generators/fae/templates/views/static_page_form.html.slim
@@ -1,15 +1,15 @@
 ruby:
-	form_options = {
-		url: fae.update_content_block_path(slug: @item.slug),
-		method: :put,
-		html: {
-			data: {
-				form_manager_model: @item.fae_form_manager_model_name,
-				form_manager_model_id: @item.fae_form_manager_model_id,
-				form_manager_info: (@form_manager.present? ? @form_manager.to_json : nil)
-			}
-		}
-	}
+  form_options = {
+    url: fae.update_content_block_path(slug: @item.slug),
+    method: :put,
+    html: {
+      data: {
+        form_manager_model: @item.fae_form_manager_model_name,
+        form_manager_model_id: @item.fae_form_manager_model_id,
+        form_manager_info: (@form_manager.present? ? @form_manager.to_json : nil)
+      }
+    }
+  }
 = simple_form_for @item, form_options do |f|
   == render 'fae/shared/form_header', header: @item
 


### PR DESCRIPTION
A few fixes for things I noticed weren't working quite right when generating new objects or pages:

* New page types now inherit from `BaseFaePageType`
* Types ignore the `:static_page` attr so it doesn't get added to the type file and break things.
* Templates indentation containing tabs is converted to spaces for consistency and better readability