### PR TITLE
74263 - Make no-search dropdowns keyboard focusable 

### DIFF
--- a/app/assets/stylesheets/fae/modules/forms/_select.scss
+++ b/app/assets/stylesheets/fae/modules/forms/_select.scss
@@ -159,7 +159,8 @@
   }
 
   .chosen-search {
-    display: none;
+    position: absolute;
+    left: -9999px;
   }
 }
 


### PR DESCRIPTION
Fae-chosen no-search functionality was display:none-ing the search input, which is what chosen uses to enable keyboard focus. Base behavior is to have the search bar off screen, so I replaced the display:none with position absolute and left position of -9999px