### PR TITLE
fix issue with undefined value being passed into validator function

### DIFF
--- a/app/assets/javascripts/fae/form/_ajax.js
+++ b/app/assets/javascripts/fae/form/_ajax.js
@@ -10,7 +10,6 @@ Fae.form.ajax = {
   init: function() {
     this.$addedit_form = $('.js-addedit-form, .js-index-addedit-form');
     this.$filter_form = $('.js-filter-form');
-    this.$nested_form = $('.nested-form');
 
     this.addEditLinks();
     this.addEditSubmission();
@@ -66,6 +65,8 @@ Fae.form.ajax = {
         $wrapper.html(data).css('height', '').find('.select select').fae_chosen();
         $wrapper.find('.input.file').fileinputer();
       }
+
+      this.$nested_form = $('.nested-form');
 
       // Bind validation to nested form fields added by AJAX
       Fae.form.validator.bindValidationEvents(this.$nested_form);


### PR DESCRIPTION
this.$nested_form = $('.nested-form') gets set on page load but .nested-form  doesn’t exist yet since it gets dynamically adding when clicking the edit link of the nested object table. that results in
an undefined value being passed to Fae.form.validator.formValidate(this.$nested_form) which means the validations don’t get scoped to the nested form and instead adds a duplicate submit event to the parent form. Leaves the user hitting the save button for the parent object with nothing happening and no errors in server or console.
this fix sets this.$nested_form = $('.nested-form') after the get request that loads the nested form