### PR TITLE
Protect global search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ spec/dummy/public/uploads/*
 
 /vendor
 docker-compose.override.yml
+.env

--- a/app/controllers/fae/utilities_controller.rb
+++ b/app/controllers/fae/utilities_controller.rb
@@ -64,7 +64,7 @@ module Fae
     def records_by_display_name(query)
       records = []
       all_models.each do |m|
-        records += m.fae_search(query)
+        records += m.fae_search(query) if m.respond_to?(:fae_search)
       end
       records
     end


### PR DESCRIPTION
Stop models that don't `include Fae::BaseModelConcern` from breaking global search.