### PR TITLE
Retire restart_hack: single idempotent Passenger restart owner

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,27 +27,11 @@ server '54.164.40.189',
 
 namespace :deploy do
 
-  desc 'Restart application'
-  task :restart do
-    on roles(:app), in: :sequence, wait: 5 do
-      # Your restart mechanism here, for example:
-      # execute :touch, shared_path.join('restart.txt')
-    end
-  end
-
   desc 'Symlink secrets.yml'
   task :symlink_secrets do
     on roles(:app) do
       execute "rm #{release_path}/spec/dummy/config/secrets.yml"
       execute "ln -s #{shared_path}/secrets.yml #{release_path}/spec/dummy/config/secrets.yml"
-    end
-  end
-
-  # deploy:restart not firing, so I added this hack for now
-  after 'deploy:symlink:release', :restart_hack do
-    on roles(:app) do
-      execute "ln -s #{shared_path}/restart.txt #{release_path}/spec/dummy/tmp/restart.txt"
-      execute :touch, release_path.join('spec', 'dummy', 'tmp','restart.txt')
     end
   end
 
@@ -60,16 +44,18 @@ namespace :deploy do
     end
   end
 
-  after :restart, :clear_cache do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      # within release_path do
-      #   execute :rake, 'cache:clear'
-      # end
-    end
-  end
-
   after 'deploy:updating', 'deploy:symlink_secrets'
   after :finishing, 'deploy:cleanup'
 
 end
+
+namespace :fine do
+  desc 'Restart Passenger by touching tmp/restart.txt (single restart owner)'
+  task :restart_passenger do
+    on roles(:app) do
+      execute :mkdir, '-p', release_path.join(fetch(:rails_path), 'tmp')
+      execute :touch, release_path.join(fetch(:rails_path), 'tmp/restart.txt')
+    end
+  end
+end
+after 'deploy:published', 'fine:restart_passenger'


### PR DESCRIPTION
Part of the fleet-wide retirement of the legacy Capistrano restart_hack, which symlinks the restart file and aborts deploys with "ln: File exists" once the site is already live (so deploy:cleanup never runs). This repo is normalized onto the same single idempotent restart owner as the rest of the fleet: fine:restart_passenger touches the app restart.txt after deploy:published. Because this is a Rails engine, the task touches spec/dummy/tmp/restart.txt (its rails_path), preserving the existing restart target. Refs Redmine #108915-#108917.
